### PR TITLE
FCBHDBP-432 DBP: coordinate with bibleis web so that content is delivered in book order

### DIFF
--- a/app/containers/Text/textRenderUtils.js
+++ b/app/containers/Text/textRenderUtils.js
@@ -82,7 +82,9 @@ export const isStartOfBible = (books, activeBookId, activeChapter) => {
 		return false;
 	}
 	// Get book that is the last in bible
-	const book = books.slice().sort((a, b) => a.book_order - b.book_order)[0];
+	const book = books
+		.slice()
+		.sort((a, b) => (a.book_order > b.book_order ? 1 : -1))[0];
 
 	if (!book) {
 		return false;
@@ -98,7 +100,9 @@ export const isEndOfBible = (books, activeBookId, activeChapter) => {
 		return false;
 	}
 	// Get book that is the last in bible
-	const book = books.slice().sort((a, b) => b.book_order - a.book_order)[0];
+	const book = books
+		.slice()
+		.sort((a, b) => (b.book_order > a.book_order ? 1 : -1))[0];
 
 	if (!book) {
 		return false;

--- a/app/utils/getBookMetaData.js
+++ b/app/utils/getBookMetaData.js
@@ -2,40 +2,39 @@ import cachedFetch from './cachedFetch';
 import removeDuplicates from './removeDuplicateObjects';
 
 export default async ({ idsForBookMetadata }) => {
-  // idsForBookMetadata is an array of arrays
-  // each child array is structured as [filesetType, filesetId]
-  // Track which results were mapped to video_stream
-  const booksWithVideo = {};
-  // Group all others together
-  const bookMetaPromises = idsForBookMetadata.map(async (filesetTuple) => {
-    const hasVideo = filesetTuple[0] === 'video_stream';
-    const url = `${process.env.BASE_API_ROUTE}/bibles/filesets/${
-      filesetTuple[1]
-    }/books?v=4&key=${process.env.DBP_API_KEY}&asset_id=${
-      hasVideo ? 'dbp-vid' : process.env.DBP_BUCKET_ID
-    }&fileset_type=${filesetTuple[0]}`;
-    const res = await cachedFetch(url);
-    if (hasVideo && res.data) {
-      res.data.forEach((book) => {
-        booksWithVideo[book.book_id] = true;
-      });
-    }
-    return {
-      [filesetTuple[1]]: res.data || [],
-    };
-  });
-  const allMetadata = await Promise.all(bookMetaPromises);
-  const dataWithoutDuplicates = removeDuplicates(
-    allMetadata.slice().reduce((reducedObjects, filesetObject) => {
-      if (Object.values(filesetObject) && Object.values(filesetObject)[0]) {
-        return [...reducedObjects, ...Object.values(filesetObject)[0]];
-      }
-      return reducedObjects;
-    }, []),
-    'book_id',
-  )
-    .map((book) => ({ ...book, hasVideo: !!booksWithVideo[book.book_id] }))
-    .sort((a, b) => a.book_order - b.book_order);
-
-  return [dataWithoutDuplicates, allMetadata];
+	// idsForBookMetadata is an array of arrays
+	// each child array is structured as [filesetType, filesetId]
+	// Track which results were mapped to video_stream
+	const booksWithVideo = {};
+	// Group all others together
+	const bookMetaPromises = idsForBookMetadata.map(async (filesetTuple) => {
+		const hasVideo = filesetTuple[0] === 'video_stream';
+		const url = `${process.env.BASE_API_ROUTE}/bibles/filesets/${
+			filesetTuple[1]
+		}/books?v=4&key=${process.env.DBP_API_KEY}&asset_id=${
+			hasVideo ? 'dbp-vid' : process.env.DBP_BUCKET_ID
+		}&fileset_type=${filesetTuple[0]}`;
+		const res = await cachedFetch(url);
+		if (hasVideo && res.data) {
+			res.data.forEach((book) => {
+				booksWithVideo[book.book_id] = true;
+			});
+		}
+		return {
+			[filesetTuple[1]]: res.data || [],
+		};
+	});
+	const allMetadata = await Promise.all(bookMetaPromises);
+	const dataWithoutDuplicates = removeDuplicates(
+		allMetadata.slice().reduce((reducedObjects, filesetObject) => {
+			if (Object.values(filesetObject) && Object.values(filesetObject)[0]) {
+				return [...reducedObjects, ...Object.values(filesetObject)[0]];
+			}
+			return reducedObjects;
+		}, []),
+		'book_id',
+	)
+		.map((book) => ({ ...book, hasVideo: !!booksWithVideo[book.book_id] }))
+		.sort((a, b) => (a.book_order > b.book_order ? 1 : -1));
+	return [dataWithoutDuplicates, allMetadata];
 };


### PR DESCRIPTION
# Description
It has done a small change to the way to sort the books by the property: book_order. According to a last change in the API (DBP) the book_order property can be of type string because the API is using to column book_seq to set the book_order property. So, we need to change the way to compare two books when we sort the books by book_order.

## Issue Link
https://fullstacklabs.atlassian.net/browse/FCBHDBP-377

## How Do I QA This
1. Navigate to [live.Bible.is](http://live.bible.is/)
2. Select the drop down menu where it says Matthew 1
3. Notice “revelations” is NOT on top because it should be last in this list

## Scree
![Screenshot from 2022-09-02 16-41-36](https://user-images.githubusercontent.com/73488660/188239080-47bffa34-92c5-457f-b243-5d3a4436fc10.png)
nshot
