### PR TITLE
FCBHDBP-517  Change Apocrypha to Deuterocanon

### DIFF
--- a/app/components/BooksTable/index.js
+++ b/app/components/BooksTable/index.js
@@ -150,11 +150,11 @@ export class BooksTable extends React.PureComponent {
 							activeChapter={activeChapter}
 						/>
 					)}
-					{!!books.get('AP') && (
+					{!!(books.get('AP') || !!books.get('DC')) && (
 						<BooksTestament
-							books={books.get('AP')}
-							testamentPrefix={'ap'}
-							testamentTitle={'Apocrypha'}
+							books={books.get('AP') || books.get('DC')}
+							testamentPrefix={'dc'}
+							testamentTitle={'Deuterocanon'}
 							selectedBookName={selectedBookName}
 							handleRef={this.handleRef}
 							handleBookClick={this.handleBookClick}


### PR DESCRIPTION
# Description
It has removed the Solomon Islands ( "SB" ) from territoryCode list to allow that Solomon Islands is displayed into country list. Also, it has been added to countryData.js file.

## Issue Link
https://fullstacklabs.atlassian.net/browse/FCBHDBP-517

## How Do I QA This
1. Navigate to [live.Bible.is](https://newdata.bible.is/bible/ENGWWH/MAT/1)
2. Select the drop down menu where it says "Matthew 1” 
3. Scroll down
4. Search label “Deuterocanon”

## Screenshots

![Screenshot from 2023-02-28 01-50-15](https://user-images.githubusercontent.com/73488660/221781545-106ac994-b5b1-4cad-a6c9-85a9d421a6f0.png)
