### PR TITLE
FCBHDBP-519 bibleis web - Portuguese display - https://live.bible.is/bible/PORNVI/2SA/2

### DIFF
--- a/static/formatted_text.scss
+++ b/static/formatted_text.scss
@@ -454,3 +454,9 @@ div.is1 {
 .mt2 + .mt3 {
 	margin-top: 0;
 }
+
+.chapter.section {
+	.nd {
+		margin-left: 0.4em;
+	}
+}


### PR DESCRIPTION
# Description
After an investigation, I have discovered that dbp-web is using a CDN html file to present the content of the requested peer book and chapter. Specifically, the html file being utilized is: [https://content.cdn.dbp-prod.dbp4.org/text/PORNVI/PORNVI/PORNVI_11_2SA_2.html....](https://content.cdn.dbp-prod.dbp4.org/text/PORNVI/PORNVI/PORNVI_11_2SA_2.html?x-amz-transaction=5860581&Expires=1677721205&Signature=NLP70oj2YdL7lFQiNoI4xgrNK8Imvm-Jgu41mR6h458OUV~wFjrSUWdzKFjMZrnCliapJUmivIJ--0X9kKKv8O03Ir~x~spT9ql-UZZDTMajmrcbEfrcBoZ6qEe2SH7I9BSMrrWNL0BVrOGF9Vw0SOyDGsdvqiuFFKPU1HdfapGHvS98ferYDHv0rDg51M8GLNQxAIMPw5SVMKpdimQs3TAMaqXLdGsQTashbPjFV9DPOxRb8L8EKxmlPfnrJhZ1tecS~u~TQimsV5feM8kLaZVTAsEfnjkl68CjJPvu~9lJS7qI0I4rmUbR5QR-cfPM5zTQyfAnYlSor3OBuotKaQ__&Key-Pair-Id=APKAI4ULLVMANLYYPTLQ)

This html file is responsible for displaying the content for the requested bible ID, which in this case is PORNVI book: 2SA and chapter: 3. Then, To address the issue of the word "Senhor", I applied the CSS class called "nd" to add appropriate spacing.

## Issue Link
https://fullstacklabs.atlassian.net/browse/FCBHDBP-517

## How Do I QA This
1. Navigate to [live.Bible.is](https://live.bible.is/bible/PORNVI/2SA/2)
2. Scroll down
4. Search paragrah “Devo ir para uma das cidades de Judá?” OSenhor respondeu que sim”

## Screenshots
- Chapter before the change
![Screenshot from 2023-02-28 21-32-47](https://user-images.githubusercontent.com/73488660/222034214-07669501-1401-480b-a778-e2a95f6cfb93.png)

- Chapter after the change
![Screenshot from 2023-02-28 21-32-37](https://user-images.githubusercontent.com/73488660/222034085-419c7d45-802d-4de6-a8bd-77856762b7f8.png)

- CSS class called "nd"
![Screenshot from 2023-02-28 21-45-36](https://user-images.githubusercontent.com/73488660/222034326-c0debc64-8283-46ee-b6fb-f08eacfc2543.png)
