### PR TITLE
FCBHDBP-560 move the @babel/cli and @babel/core dev dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,6 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/cli": "^7.15.0",
-        "@babel/core": "^7.15.0",
         "@bugsnag/js": "^7.20.2",
         "@bugsnag/plugin-react": "^7.19.0",
         "@next/bundle-analyzer": "^13.3.1",
@@ -69,6 +67,8 @@
         "whatwg-fetch": "3.6.2"
       },
       "devDependencies": {
+        "@babel/cli": "^7.15.0",
+        "@babel/core": "^7.15.0",
         "@babel/eslint-parser": "^7.21.3",
         "@babel/node": "^7.15.0",
         "@babel/plugin-transform-classes": "^7.14.5",
@@ -155,6 +155,7 @@
       "version": "7.21.5",
       "resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.21.5.tgz",
       "integrity": "sha512-TOKytQ9uQW9c4np8F+P7ZfPINy5Kv+pizDIUwSVH8X5zHgYHV4AA8HE5LA450xXeu4jEfmUckTYvv1I4S26M/g==",
+      "dev": true,
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.17",
         "commander": "^4.0.1",
@@ -3604,6 +3605,7 @@
       "version": "2.1.8-no-fsevents.3",
       "resolved": "https://registry.npmjs.org/@nicolo-ribaudo/chokidar-2/-/chokidar-2-2.1.8-no-fsevents.3.tgz",
       "integrity": "sha512-s88O1aVtXftvp5bCPB7WnmXc5IwOZZ7YPuwNPt+GtOOXpPvad1LfbmjYv+qII7zP6RU2QGnqve27dnLycEnyEQ==",
+      "dev": true,
       "optional": true
     },
     "node_modules/@nicolo-ribaudo/eslint-scope-5-internals": {
@@ -7331,6 +7333,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
       "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "dev": true,
       "engines": {
         "node": ">= 6"
       }
@@ -9879,7 +9882,8 @@
     "node_modules/fs-readdir-recursive": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-1.1.0.tgz",
-      "integrity": "sha512-GNanXlVr2pf02+sPN40XN8HG+ePaNcvM0q5mZBd668Obwb0yD5GiUbZOFgwn8kGMY6I3mdyDJzieUy3PTYyTRA=="
+      "integrity": "sha512-GNanXlVr2pf02+sPN40XN8HG+ePaNcvM0q5mZBd668Obwb0yD5GiUbZOFgwn8kGMY6I3mdyDJzieUy3PTYyTRA==",
+      "dev": true
     },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
@@ -14003,6 +14007,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
       "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
+      "dev": true,
       "dependencies": {
         "pify": "^4.0.1",
         "semver": "^5.6.0"
@@ -14015,6 +14020,7 @@
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
       "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "dev": true,
       "bin": {
         "semver": "bin/semver"
       }
@@ -15508,6 +15514,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
       "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -17737,6 +17744,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
       "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+      "dev": true,
       "engines": {
         "node": ">=6"
       }

--- a/package.json
+++ b/package.json
@@ -224,8 +224,6 @@
     "@xmldom/xmldom": "^0.8.7",
     "axios": "^1.3.6",
     "babel-plugin-formatjs": "^10.5.0",
-    "@babel/cli": "^7.15.0",
-    "@babel/core": "^7.15.0",
     "chalk": "^5.2.0",
     "compression": "^1.7.4",
     "core-js": "^3.30.1",
@@ -277,6 +275,8 @@
     "whatwg-fetch": "3.6.2"
   },
   "devDependencies": {
+    "@babel/cli": "^7.15.0",
+    "@babel/core": "^7.15.0",
     "@babel/eslint-parser": "^7.21.3",
     "@babel/node": "^7.15.0",
     "@babel/plugin-transform-classes": "^7.14.5",


### PR DESCRIPTION
# Description
Moved the  and  as dev dependencies to avoid to have the bundles in production environment.

## Related Issue

https://fullstacklabs.atlassian.net/browse/FCBHDBP-560

## How to Test
- The deployment process have to be executed successful.
