### PR TITLE
FCBHDBP-565 Fixed an issue in which the API was being called to fetch…

### DIFF
--- a/app/utils/getValidPlainFilesetsByBook.js
+++ b/app/utils/getValidPlainFilesetsByBook.js
@@ -1,0 +1,37 @@
+/**
+ * Filter the list of plain Fileset Ids to include only those that belong to the same testament as the given book.
+ *
+ * @param {Book{testament:string}} book
+ * @param {Array[type, fileset_id, testament]} filesetIdsForBookMetadata
+ * @param {Array} plainFilesetIds
+ * @returns
+ */
+const getValidPlainFilesetsByBook = (
+	book,
+	filesetIdsForBookMetadata,
+	plainFilesetIds,
+) => {
+	const idsForBookMetadataIndexed = {};
+
+	filesetIdsForBookMetadata.forEach((fileset) => {
+		if (fileset[1]) {
+			idsForBookMetadataIndexed[fileset[1]] = {
+				type: fileset[0],
+				id: fileset[1],
+				testament: fileset[2],
+			};
+		}
+	});
+
+	return plainFilesetIds.filter((filesetId) => {
+		// 1. If the Fileset testament is NTP, it will only be considered valid if the testament of the book is also NT.
+		// 2. A Fileset with a testament code of C is considered valid because it includes both the Old and New Testaments.
+		//    This is because the C size code denotes a fileset that includes content from both testaments.
+		return (
+			idsForBookMetadataIndexed[filesetId]?.testament == 'C' ||
+			idsForBookMetadataIndexed[filesetId]?.testament.includes(book.testament)
+		);
+	});
+};
+
+export default getValidPlainFilesetsByBook;

--- a/package.json
+++ b/package.json
@@ -53,7 +53,8 @@
     "reload:pm2": "pm2 reload ecosystem.config.js --update-env --env production --only bible.is.prod;",
     "fetch-latest-site": "git checkout .; rm package-lock.json; git pull origin master; npm install; npm run npmpostinstall; npm run build:prod; pm2 restart ecosystem.config.js --update-env --env production --only bible.is.production;",
     "update-staging": "git checkout .; rm package-lock.json; git pull origin staging; npm install; npm run npmpostinstall; npm run build:staging; pm2 restart ecosystem.config.js --only bible.is.staging;",
-    "fetch-latest-dev": "git checkout .; rm package-lock.json; git pull origin development; npm install; npm run build; npm run npmpostinstall; pm2 restart ecosystem.config.js --update-env --env production --only bible.is.development;"
+    "fetch-latest-dev": "git checkout .; rm package-lock.json; git pull origin development; npm install; npm run build; npm run npmpostinstall; pm2 restart ecosystem.config.js --update-env --env production --only bible.is.development;",
+    "prettier": "prettier --single-quote=true --arrow-parens=always --use-tabs --write --single-quote --trailing-comma=all"
   },
   "lint-staged": {
     "*.{js,json,scss,md}": [


### PR DESCRIPTION
# Description
Fixed an issue where the API was attempting to fetch verses of a text fileset using a book that was not associated with the fileset. This was causing errors when trying to access the bible ID JPNCJV, as dbp-web was calling the endpoint to get the books using the fileset JPNCJVO_ET and filtering by book ID MAT, despite the fileset not being attached to the New Testament.

To address this, I have added a validation in dbp-web to check if the fileset is attached to the specific book before invoking the endpoint. However, I recommend checking the API endpoint as well to ensure the logic is adjusted accordingly.

I have created ticket FCBHDBP-570 to address this issue in the API. https://fullstacklabs.atlassian.net/browse/FCBHDBP-570

## Related Issue

https://fullstacklabs.atlassian.net/browse/FCBHDBP-560

## How to Test
- You should go the path: bible/JPNCJV/MAT/1 and it must load the correct page.

## Screenshot

[Screencast from 05-05-2023 04:47:17 PM.webm](https://user-images.githubusercontent.com/73488660/236582987-84b2dd40-cbe6-4f54-b59c-f0e81da54e34.webm)
