### PR TITLE
FCBHDBP-567 bibleis web - pagination traversal logic for languages and countries

### DIFF
--- a/app/containers/HomePage/index.js
+++ b/app/containers/HomePage/index.js
@@ -231,7 +231,8 @@ class HomePage extends React.PureComponent {
       prevVerseNumber !== verseNumber ||
       formattedSource.main !== prevFormattedSource.main ||
       !isEqual(prevTextData.text, textData.text) ||
-      audioSource !== prevAudioSource
+      audioSource !== prevAudioSource ||
+      activeChapter !== activeChapterProps
     ) {
       this.setTextLoadingState({ state: false });
       this.getCopyrights({ filesetIds: activeFilesets });

--- a/app/utils/bugsnagClient.js
+++ b/app/utils/bugsnagClient.js
@@ -4,15 +4,15 @@ import BugsnagPluginReact from '@bugsnag/plugin-react';
 const bugsnagClient =
 	process.env.NODE_ENV === 'development'
 		? {
-        use: () => {},
-        notify: () => {},
-        getPlugin: () => ({
-          createErrorBoundary: () => (Component) => Component,
-        }),
+				use: () => {},
+				notify: () => {},
+				getPlugin: () => ({
+					createErrorBoundary: () => (Component) => Component,
+				}),
 		  }
 		: Bugsnag.createClient({
-			apiKey: process.env.BUGSNAG_API_KEY,
-			plugins: [new BugsnagPluginReact()],
-		});
+				apiKey: process.env.BUGSNAG_API_KEY,
+				plugins: [new BugsnagPluginReact()],
+		  });
 
 export default bugsnagClient;

--- a/app/utils/tests/__snapshots__/constants.test.js.snap
+++ b/app/utils/tests/__snapshots__/constants.test.js.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Test contstants in utils should match old snapshot 1`] = `"{\\"RESTART_ON_REMOUNT\\":\\"@@saga-injector/restart-on-remount\\",\\"DAEMON\\":\\"@@saga-injector/daemon\\",\\"ONCE_TILL_UNMOUNT\\":\\"@@saga-injector/once-till-unmount\\"}"`;
+exports[`Test contstants in utils should match old snapshot 1`] = `"{"DAEMON":"@@saga-injector/daemon","ONCE_TILL_UNMOUNT":"@@saga-injector/once-till-unmount","RESTART_ON_REMOUNT":"@@saga-injector/restart-on-remount"}"`;

--- a/app/utils/tests/__snapshots__/listOfBooksInBible.test.js.snap
+++ b/app/utils/tests/__snapshots__/listOfBooksInBible.test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`List of books in bible utility data should match previous snapshot 1`] = `
-Object {
+{
   "1CH": "1 Chronicles",
   "1CO": "1 Corinthians",
   "1JN": "1 John",

--- a/app/utils/tests/__snapshots__/reduxPersist.test.js.snap
+++ b/app/utils/tests/__snapshots__/reduxPersist.test.js.snap
@@ -1,18 +1,18 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`redux persist utility config should match previous snapshot 1`] = `
-Object {
+{
   "active": true,
   "reducerKey": "Bible.is",
   "reducerVersion": "1",
-  "storeConfig": Object {
-    "blacklist": Array [
+  "storeConfig": {
+    "blacklist": [
       "homepage",
       "textSelection",
     ],
     "keyPrefix": "Bible.is.v1.",
     "stateReconciler": [Function],
-    "whitelist": Array [
+    "whitelist": [
       "profile",
       "settings",
       "searchContainer",

--- a/app/utils/tests/bugsnagClient.test.js
+++ b/app/utils/tests/bugsnagClient.test.js
@@ -1,18 +1,19 @@
 import bugsnagClient from '../bugsnagClient';
 
-jest.mock('@bugsnag/js', () =>
-  jest.fn(() => ({
+jest.mock('@bugsnag/js', () => ({
+  createClient: () => ({
     use: jest.fn(),
     notify: jest.fn(),
     getPlugin: jest.fn(),
-  })),
-);
+  }),
+}));
+
 jest.mock('@bugsnag/plugin-react', () => jest.fn());
 
 describe('bugsnag server utility function', () => {
-  it('should return an object with the appropriate handlers', () => {
-    expect(bugsnagClient).toHaveProperty('use');
-    expect(bugsnagClient).toHaveProperty('notify');
-    expect(bugsnagClient).toHaveProperty('getPlugin');
-  });
+	it('should return an object with the appropriate handlers', () => {
+		expect(bugsnagClient).toHaveProperty('use');
+		expect(bugsnagClient).toHaveProperty('notify');
+		expect(bugsnagClient).toHaveProperty('getPlugin');
+	});
 });

--- a/app/utils/tests/bugsnagServer.test.js
+++ b/app/utils/tests/bugsnagServer.test.js
@@ -1,12 +1,13 @@
 import bugsnagServer from '../bugsnagServer';
 
-jest.mock('@bugsnag/js', () =>
-  jest.fn(() => ({
+jest.mock('@bugsnag/js', () => ({
+  createClient: () => ({
     use: jest.fn(),
     notify: jest.fn(),
     getPlugin: jest.fn(),
-  })),
-);
+  }),
+}));
+
 jest.mock('@bugsnag/plugin-react', () => jest.fn());
 
 describe('bugsnag server utility function', () => {

--- a/pages/app.js
+++ b/pages/app.js
@@ -437,6 +437,7 @@ AppContainer.getInitialProps = async (context) => {
         bible.filesets[process.env.DBP_BUCKET_ID].length === 1,
     );
   } else if (bible && bible.filesets && bible.filesets['dbp-vid']) {
+    hasVideo = true;
     filesets = bible.filesets['dbp-vid'].filter(
       (file) =>
         (!file.id.includes('GID') &&


### PR DESCRIPTION
# Description
Add feature to call the languages and the countries endpoints asynchronously.


# Note 1
I have fixed an issue related to chapters that don't have text but have video. Previously, these chapters were not visible when clicking on the right or left arrow. This issue has been resolved and the fix has been implemented in the file: [pages/app.js](https://github.com/faithcomesbyhearing/dbp-web/compare/nodejs18...faithcomesbyhearing:dbp-web:FCBHDBP-567?expand=1#diff-d98ab53a129300f7454605cce4fdb08985aaae230e1b2333017c44368c0a9b43)

## Related Issue

https://fullstacklabs.atlassian.net/browse/FCBHDBP-567

## How to Test
- You should go the home page and the languages and countries menu must load the correct values.
- You should got the path: /bible/spalpf/mat/13 and you must be able to see the chapters if you click on the right or left arrow.
 
## Screenshot
I have tested the changes locally and can confirm that the languages and countries endpoints are now being called asynchronously as you can see in the following screenshot.
![Screenshot from 2023-05-10 15-33-33](https://github.com/faithcomesbyhearing/dbp-web/assets/73488660/58981d64-d2a2-49da-a4f3-265e571869de)

