### PR TITLE
FCBHDBP-575 Check and Validate endpoint to return the books and chapters for a specific fileset

### DIFF
--- a/app/components/EditNote/index.js
+++ b/app/components/EditNote/index.js
@@ -41,7 +41,6 @@ class EditNote extends React.PureComponent {
 		};
 	}
 
-	// componentDidUpdate(nextProps) {
 	componentDidUpdate() {
 		if (this.state.savingNote && this.props.savedTheNote) {
 			this.setState({ savingNote: false });

--- a/app/containers/AudioPlayer/index.js
+++ b/app/containers/AudioPlayer/index.js
@@ -628,6 +628,7 @@ export class AudioPlayer extends React.Component {
       autoPlay,
       volume,
       playbackRate,
+      activeTextId,
     } = this.props;
 
     return (
@@ -685,7 +686,7 @@ export class AudioPlayer extends React.Component {
                 books: this.props.books,
                 chapter: this.props.activeChapter,
                 bookId: this.props.activeBookId.toLowerCase(),
-                textId: this.props.activeTextId.toLowerCase(),
+                textId: activeTextId.toLowerCase(),
                 verseNumber: this.props.verseNumber,
                 text: this.props.textData.text,
                 audioType,
@@ -706,7 +707,7 @@ export class AudioPlayer extends React.Component {
                 books: this.props.books,
                 chapter: this.props.activeChapter,
                 bookId: this.props.activeBookId.toLowerCase(),
-                textId: this.props.activeTextId.toLowerCase(),
+                textId: activeTextId.toLowerCase(),
                 verseNumber: this.props.verseNumber,
                 text: this.props.textData.text,
                 audioType,
@@ -825,7 +826,7 @@ AudioPlayer.propTypes = {
   audioSource: PropTypes.string,
   audioType: PropTypes.string,
   activeBookId: PropTypes.string,
-  activeTextId: PropTypes.string,
+  activeTextId: PropTypes.string.isRequired,
   verseNumber: PropTypes.string,
   dispatch: PropTypes.func,
   hasAudio: PropTypes.bool,

--- a/app/containers/AudioPlayer/selectors.js
+++ b/app/containers/AudioPlayer/selectors.js
@@ -1,7 +1,7 @@
 import { createSelector } from 'reselect';
 
 const toJs = (state) =>
-	typeof state.toJS === 'function' ? state.toJS() : state;
+	typeof state?.toJS === 'function' ? state.toJS() : state;
 /**
  * Direct selector to the audioPlayer state domain
  */

--- a/app/containers/HomePage/index.js
+++ b/app/containers/HomePage/index.js
@@ -466,7 +466,7 @@ class HomePage extends React.PureComponent {
               : 'content-container'
           }
         >
-          {(
+          {(activeTextId && (
               <VideoPlayer
                 fileset={
                   activeFilesets.filter((f) => f.type === 'video_stream')[0]
@@ -477,25 +477,28 @@ class HomePage extends React.PureComponent {
                 text={updatedText}
                 textId={activeTextId}
               />
-            )}
-          <Text
-            books={books}
-            text={updatedText}
-            hasVideo={hasVideo}
-            verseNumber={verse}
-            audioType={audioType}
-            menuIsOpen={isMenuOpen}
-            activeTextId={activeTextId}
-            activeBookId={activeBookId}
-            loadingAudio={loadingAudio}
-            activeChapter={activeChapter}
-            changingVersion={changingVersion}
-            videoPlayerOpen={videoPlayerOpen}
-            isScrollingDown={isScrollingDown}
-            audioPlayerState={audioPlayerState}
-            loadingNewChapterText={loadingNewChapterText}
-            chapterTextLoadingState={chapterTextLoadingState}
-          />
+            )
+          )}
+          { activeTextId && (
+              <Text
+              books={books}
+              text={updatedText}
+              hasVideo={hasVideo}
+              verseNumber={verse}
+              audioType={audioType}
+              menuIsOpen={isMenuOpen}
+              activeTextId={activeTextId}
+              activeBookId={activeBookId}
+              loadingAudio={loadingAudio}
+              activeChapter={activeChapter}
+              changingVersion={changingVersion}
+              videoPlayerOpen={videoPlayerOpen}
+              isScrollingDown={isScrollingDown}
+              audioPlayerState={audioPlayerState}
+              loadingNewChapterText={loadingNewChapterText}
+              chapterTextLoadingState={chapterTextLoadingState}
+              />
+          )}
         </div>
         <TransitionGroup>
           {isSettingsModalActive ? (
@@ -550,7 +553,7 @@ class HomePage extends React.PureComponent {
             </FadeTransition>
           ) : null}
         </TransitionGroup>
-        <AudioPlayer verseNumber={verse} audioType={audioType} />
+        {activeTextId && <AudioPlayer verseNumber={verse} audioType={audioType} />}
         <Footer
           profileActive={isProfileActive}
           searchActive={isSearchModalActive}
@@ -569,7 +572,38 @@ class HomePage extends React.PureComponent {
 
 HomePage.propTypes = {
   dispatch: PropTypes.func.isRequired,
-  homepage: PropTypes.object.isRequired,
+  homepage: PropTypes.shape({
+    activeBookId: PropTypes.string,
+    activeTextId: PropTypes.string.isRequired,
+    activeChapter: PropTypes.number,
+    activeBookName: PropTypes.string,
+    activeFilesets: PropTypes.array,
+    activeTextName: PropTypes.string,
+    activeFilesetId: PropTypes.string,
+    audioPlayerState: PropTypes.bool,
+    books: PropTypes.array,
+    isProfileActive: PropTypes.bool,
+    isNotesModalActive: PropTypes.bool,
+    isSearchModalActive: PropTypes.bool,
+    isSettingsModalActive: PropTypes.bool,
+    isVersionSelectionActive: PropTypes.bool,
+    isChapterSelectionActive: PropTypes.bool,
+    userAgent: PropTypes.string,
+    loadingAudio: PropTypes.bool,
+    loadingNewChapterText: PropTypes.bool,
+    chapterTextLoadingState: PropTypes.bool,
+    changingVersion: PropTypes.bool,
+    videoPlayerOpen: PropTypes.bool,
+    hasVideo: PropTypes.bool,
+    audioType: PropTypes.string,
+    textDirection: PropTypes.string,
+    match: PropTypes.object,
+    firstLoad: PropTypes.bool,
+    addBookmarkSuccess: PropTypes.bool,
+    defaultLanguageIso: PropTypes.string,
+    defaultLanguageCode: PropTypes.number,
+    audioSource: PropTypes.string,
+  }).isRequired,
   userSettings: PropTypes.object,
   formattedSource: PropTypes.object,
   userAuthenticated: PropTypes.bool,

--- a/app/containers/Notes/saga.js
+++ b/app/containers/Notes/saga.js
@@ -156,6 +156,16 @@ export function* updateNote({ userId, data, noteId }) {
 
     if (response.success) {
       yield put({ type: ADD_NOTE_SUCCESS, response });
+      yield fork(getNotesForChapter, {
+        userId,
+        params: {
+          bible_id: data.bible_id,
+          book_id: data.book_id,
+          chapter: data.chapter,
+          limit: 150,
+          page: 1,
+        },
+      });
     }
   } catch (err) {
     if (process.env.NODE_ENV === 'development') {
@@ -229,22 +239,6 @@ export function* deleteNote({
       const response = yield call(request, requestUrl, options);
 
       if (response.success) {
-        if (isBookmark) {
-          yield fork(getUserBookmarks, {
-            userId,
-            params: { limit: pageSize, page: activePage },
-          });
-          yield fork(getBookmarksForChapter, {
-            userId,
-            params: {
-              bible_id: bibleId,
-              book_id: bookId,
-              chapter,
-              limit: 150,
-              page: 1,
-            },
-          });
-        }
         yield fork(getNotesForNotebook, {
           userId,
           params: { limit: pageSize, page: activePage },

--- a/app/containers/Text/index.js
+++ b/app/containers/Text/index.js
@@ -177,7 +177,7 @@ Text.propTypes = {
 	chapterTextLoadingState: PropTypes.bool,
 	audioType: PropTypes.string,
 	verseNumber: PropTypes.string,
-	activeTextId: PropTypes.string,
+	activeTextId: PropTypes.string.isRequired,
 	activeBookId: PropTypes.string,
 };
 

--- a/nextServer.js
+++ b/nextServer.js
@@ -8,7 +8,7 @@ if (
 }
 require('core-js');
 require('regenerator-runtime');
-
+const lscache = require('lscache');
 const dotenv = require('dotenv');
 if (process.env.NODE_ENV !== 'production') {
 	dotenv.config();
@@ -113,7 +113,8 @@ app
     });
 
     server.get('/clean-the-cash', (req, res) => {
-      ssrCache.reset();
+      ssrCache.clear();
+      lscache.flush();
       res.send('Cleaned the cache');
     });
 

--- a/pages/app.js
+++ b/pages/app.js
@@ -19,6 +19,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import Head from 'next/head';
 import Router, { useRouter } from 'next/router';
+import axios from 'axios';
 import cachedFetch, { overrideCache } from '../app/utils/cachedFetch';
 import HomePage from '../app/containers/HomePage';
 import getinitialChapterData from '../app/utils/getInitialChapterData';
@@ -378,8 +379,9 @@ AppContainer.getInitialProps = async (context) => {
 
   // Get active bible data
   const singleBibleRes = await cachedFetch(singleBibleUrl).catch((e) => {
-    if (process.env.NODE_ENV === 'development') {
-      console.error('Error in get initial props single bible: ', e.message); // eslint-disable-line no-console
+    console.error('Error in get initial props single bible: ', e.message); // eslint-disable-line no-console
+    if (axios.isAxiosError(e)) {
+      console.error('Error occurred at URL:', e.config.url); // eslint-disable-line no-console
     }
     return { data: {} };
   });
@@ -640,7 +642,7 @@ AppContainer.getInitialProps = async (context) => {
         activeChapter: parseInt(chapter, 10) >= 0 ? parseInt(chapter, 10) : 1,
         activeBookName,
         verseNumber: verse,
-        activeTextId: bible.abbr || '',
+        activeTextId: bible.abbr,
         activeIsoCode: bible.iso || '',
         defaultLanguageIso: bible.iso || 'eng',
         activeLanguageName: bible.language || '',


### PR DESCRIPTION
# Description
Add validation that prevents the redirect when the API returns an error. Instead, a message will be displayed to notify in the log when the API returns a 404 or 500 error.

# Changes log
1. The activeTextId property is now required and must have a value other than undefined in order to allow rendering for components such as VideoPlayer, Text, and AudioPlayer.
2. When a note is updated, the list of user notes must also be updated with the new values.

## Related Issue

https://fullstacklabs.atlassian.net/browse/FCBHDBP-571

## How to Test
- To view the notification message in the log, please visit the home page. If the API returns an error, a notification message similar to the screenshot below will be displayed in the log.

![Screenshot from 2023-05-18 11-55-25](https://github.com/faithcomesbyhearing/dbp-web/assets/73488660/e1af2c75-80d3-4c91-a00e-7d38950998e8)

 