### PR TITLE
 FCBHDBP-576 Refine Requests to Exclude Filesets Not Matching the Correct Testament

### DIFF
--- a/app/components/VersionList/index.js
+++ b/app/components/VersionList/index.js
@@ -22,272 +22,283 @@ import { selectHasVideo } from '../../containers/VideoPlayer/selectors';
 import getUrl from '../../utils/hrefLinkOrAsLink';
 
 export class VersionList extends React.PureComponent {
-	get filteredVersionList() {
-		const { bibles, activeTextId, filterText, activeChapter, activeBookId } =
-			this.props;
-		const filteredBibles = filterText
-			? bibles?.filter(this.filterFunction)
-			: bibles;
+  get filteredVersionList() {
+    const {
+      bibles,
+      activeTextId,
+      filterText,
+      activeChapter,
+      activeBookId,
+    } = this.props;
+    const filteredBibles = filterText
+      ? bibles?.filter(this.filterFunction)
+      : bibles;
 
-		const getKey = (bible) => {
-			if (!bible) return '';
-			const abbr = bible.get('abbr');
-			const date = bible.get('date') || '2019';
-			const typeSuffix = bible.get('hasVideo') ? '_video' : '_plain';
-			return abbr + date + typeSuffix;
-		};
+    const getKey = (bible) => {
+      if (!bible) return '';
+      const abbr = bible.get('abbr');
+      const date = bible.get('date') || '2019';
+      const typeSuffix = bible.get('hasVideo') ? '_video' : '_plain';
+      return abbr + date + typeSuffix;
+    };
 
-		// Change the way I figure out if a resource has text or audio
-		// path, key, types, className, text, clickHandler
-		// Set the path to just the bible_id and let app.js handle getting the actual book and chapter needed
-		const scrubbedBibles = filteredBibles?.reduce((acc, bible) => {
-			const item = {
-				path: {
-					textId: bible.get('abbr'),
-					bookId: activeBookId,
-					chapter: activeChapter,
-				},
-				key: getKey(bible),
-				clickHandler: (audioType) =>
-					this.handleVersionListClick(bible, audioType),
-				className: bible.get('abbr') === activeTextId ? 'active-version' : '',
-				title: bible.get('name'),
-				text: bible.get('vname') || bible.get('name') || bible.get('abbr'),
-				altText:
-					bible.get('vname') && bible.get('vname') !== bible.get('name')
-						? bible.get('name')
-						: '',
-				types: bible.get('filesets')
-					? bible
-							.get('filesets')
-							.reduce((a, c) => ({ ...a, [c.get('type')]: true }), {})
-					: {},
-			};
+    // Change the way I figure out if a resource has text or audio
+    // path, key, types, className, text, clickHandler
+    // Set the path to just the bible_id and let app.js handle getting the actual book and chapter needed
+    const scrubbedBibles = filteredBibles?.reduce((acc, bible) => {
+      const item = {
+        path: {
+          textId: bible.get('abbr'),
+          bookId: activeBookId,
+          chapter: activeChapter,
+        },
+        key: getKey(bible),
+        clickHandler: (audioType) => this.handleVersionListClick(bible, audioType),
+        className: bible.get('abbr') === activeTextId ? 'active-version' : '',
+        title: bible.get('name'),
+        text: bible.get('vname') || bible.get('name') || bible.get('abbr'),
+        altText:
+          bible.get('vname') && bible.get('vname') !== bible.get('name')
+            ? bible.get('name')
+            : '',
+        types: bible.get('filesets')
+          ? bible
+            .get('filesets')
+            .reduce((a, c) => ({ ...a, [c.get('type')]: true }), {})
+          : {},
+      };
 
-			acc.push(item);
-			return acc;
-		}, []);
+      acc.push(item);
+      return acc;
+    }, []);
 
-		// When I first get the response from the server with filesets
-		const video = [];
-		const audioAndText = [];
-		const audioOnly = [];
-		const textOnly = [];
+    // When I first get the response from the server with filesets
+    const video = [];
+    const audioAndText = [];
+    const audioOnly = [];
+    const textOnly = [];
 
-		scrubbedBibles?.forEach((b) => {
-			if (b.types.video_stream) {
-				video.push(b);
-			} else if (
-				(b.types.audio_drama || b.types.audio) &&
-				(b.types.text_plain || b.types.text_format)
-			) {
-				audioAndText.push(b);
-			} else if (b.types.audio_drama || b.types.audio) {
-				audioOnly.push(b);
-			} else {
-				textOnly.push(b);
-			}
-		});
+    scrubbedBibles?.forEach((b) => {
+      if (b.types.video_stream) {
+        video.push(b);
+      } else if (
+        (b.types.audio_drama || b.types.audio) &&
+        (b.types.text_plain || b.types.text_format)
+      ) {
+        audioAndText.push(b);
+      } else if (b.types.audio_drama || b.types.audio) {
+        audioOnly.push(b);
+      } else {
+        textOnly.push(b);
+      }
+    });
 
-		const videoComponent = video?.length ? (
-			<div className={'version-list-section'} key={'video'}>
-				<div className={'version-list-section-title'}>
-					<FormattedMessage {...messages.video} />
-				</div>
-				<VersionListSection items={video} />
-			</div>
-		) : null;
-		const audioAndTextComponent = audioAndText.length ? (
-			<div className={'version-list-section'} key={'audio-and-text'}>
-				<div className={'version-list-section-title'}>
-					<FormattedMessage {...messages.audioAndText} />
-				</div>
-				<VersionListSection items={audioAndText} />
-			</div>
-		) : null;
-		const audioOnlyComponent = audioOnly.length ? (
-			<div className={'version-list-section'} key={'audio-only'}>
-				<div className={'version-list-section-title'}>
-					<FormattedMessage {...messages.audioOnly} />
-				</div>
-				<VersionListSection items={audioOnly} />
-			</div>
-		) : null;
-		const textOnlyComponent = textOnly.length ? (
-			<div className={'version-list-section'} key={'text-only'}>
-				<div className={'version-list-section-title'}>
-					<FormattedMessage {...messages.textOnly} />
-				</div>
-				<VersionListSection items={textOnly} />
-			</div>
-		) : null;
+    const videoComponent = video?.length ? (
+      <div className={'version-list-section'} key={'video'}>
+        <div className={'version-list-section-title'}>
+          <FormattedMessage {...messages.video} />
+        </div>
+        <VersionListSection items={video} />
+      </div>
+    ) : null;
+    const audioAndTextComponent = audioAndText.length ? (
+      <div className={'version-list-section'} key={'audio-and-text'}>
+        <div className={'version-list-section-title'}>
+          <FormattedMessage {...messages.audioAndText} />
+        </div>
+        <VersionListSection items={audioAndText} />
+      </div>
+    ) : null;
+    const audioOnlyComponent = audioOnly.length ? (
+      <div className={'version-list-section'} key={'audio-only'}>
+        <div className={'version-list-section-title'}>
+          <FormattedMessage {...messages.audioOnly} />
+        </div>
+        <VersionListSection items={audioOnly} />
+      </div>
+    ) : null;
+    const textOnlyComponent = textOnly.length ? (
+      <div className={'version-list-section'} key={'text-only'}>
+        <div className={'version-list-section-title'}>
+          <FormattedMessage {...messages.textOnly} />
+        </div>
+        <VersionListSection items={textOnly} />
+      </div>
+    ) : null;
 
-		const components = [
-			videoComponent,
-			audioAndTextComponent,
-			audioOnlyComponent,
-			textOnlyComponent,
-		];
+    const components = [
+      videoComponent,
+      audioAndTextComponent,
+      audioOnlyComponent,
+      textOnlyComponent,
+    ];
 
-		if (bibles?.size === 0) {
-			return (
-				<span className="version-item-button">
-					There was an error fetching this resource, an Admin has been notified.
-					We apologize for the inconvenience.
-				</span>
-			);
-		}
+    if (bibles?.size === 0) {
+      return (
+        <span className="version-item-button">
+          There was an error fetching this resource, an Admin has been notified.
+          We apologize for the inconvenience.
+        </span>
+      );
+    }
 
-		return scrubbedBibles?.length ? (
-			components
-		) : (
-			<span className="version-item-button">
-				There are no matches for your search.
-			</span>
-		);
-	}
+    return scrubbedBibles?.length ? (
+      components
+    ) : (
+      <span className="version-item-button">
+        There are no matches for your search.
+      </span>
+    );
+  }
 
-	filterFunction = (bible) => {
-		const lowerCaseText = this.props.filterText.toLowerCase();
-		const properties = ['vname', 'name', 'abbr', 'date'];
+  filterFunction = (bible) => {
+    const lowerCaseText = this.props.filterText.toLowerCase();
+    const properties = ['vname', 'name', 'abbr', 'date'];
 
-		return properties.some((property) => {
-			const propValue = bible.get(property) || '';
-			return propValue.toLowerCase().includes(lowerCaseText);
-		});
-	};
+    return properties.some((property) => {
+      const propValue = bible.get(property) || '';
+      return propValue.toLowerCase().includes(lowerCaseText);
+    });
+  };
 
-	// Make async
-	handleVersionListClick = async (bible, audioType) => {
-		// Figure out correct url here based on session variable value
-		const { toggleTextSelection, activeTextId, activeBookId, activeChapter } =
-			this.props;
-		const hasVideo = !!bible.get('hasVideo');
+  // Make async
+  handleVersionListClick = async (bible, audioType) => {
+    // Figure out correct url here based on session variable value
+    const {
+      toggleTextSelection,
+      activeTextId,
+      activeBookId,
+      activeChapter,
+    } = this.props;
+    const hasVideo = !!bible.get('hasVideo');
 
-		if (bible.get('jesusFilm')) {
-			// If there is a Jesus Film then use alternate navigation logic
-			Router.push(`/jesus-film/${bible.get('iso')}`);
-			toggleTextSelection();
-			// End function early since navigation should have already occurred
-			return;
-		}
-		// If bible id is equal to the active bible id then just return and don't change version
-		if (bible.get('abbr').toLowerCase() === activeTextId.toLowerCase()) {
-			toggleTextSelection();
-			return;
-		}
+    if (bible.get('jesusFilm')) {
+      // If there is a Jesus Film then use alternate navigation logic
+      Router.push(`/jesus-film/${bible.get('iso')}`);
+      toggleTextSelection();
+      // End function early since navigation should have already occurred
+      return;
+    }
+    // If bible id is equal to the active bible id then just return and don't change version
+    if (bible.get('abbr').toLowerCase() === activeTextId.toLowerCase()) {
+      toggleTextSelection();
+      return;
+    }
 
-		if (bible.get('abbr').toLowerCase() !== activeTextId.toLowerCase()) {
-			this.props.dispatch(changeVersion({ state: true }));
-		}
+    if (bible.get('abbr').toLowerCase() !== activeTextId.toLowerCase()) {
+      this.props.dispatch(changeVersion({ state: true }));
+    }
 
-		if (JSON.parse(sessionStorage.getItem('bible_is_maintain_location'))) {
-			Router.push(
-				getUrl({
-					textId: bible.get('abbr'),
-					bookId: activeBookId,
-					chapter: activeChapter,
-					audioType,
-					isHref: true,
-				}),
-				getUrl({
-					textId: bible.get('abbr'),
-					bookId: activeBookId,
-					chapter: activeChapter,
-					audioType,
-					isHref: false,
-				}),
-			);
-		} else {
-			// Find url and push that one
-			const [filteredMetadata, allMetadata] = await getBookMetaData({
-				idsForBookMetadata: bible
-					.get('filesets')
-					.map((set) => [set.get('type'), set.get('id')])
-					.toJS(),
-			});
+    if (JSON.parse(sessionStorage.getItem('bible_is_maintain_location'))) {
+      Router.push(
+        getUrl({
+          textId: bible.get('abbr'),
+          bookId: activeBookId,
+          chapter: activeChapter,
+          audioType,
+          isHref: true,
+        }),
+        getUrl({
+          textId: bible.get('abbr'),
+          bookId: activeBookId,
+          chapter: activeChapter,
+          audioType,
+          isHref: false,
+        }),
+      );
+    } else {
+      // Find url and push that one
+      const [filteredMetadata, allMetadata] = await getBookMetaData({
+        idsForBookMetadata: bible
+          .get('filesets')
+          .map((set) => [set.get('type'), set.get('id')])
+          .toJS(),
+      });
 
-			const bookChapterUrl = getFirstChapterReference(
-				bible.get('filesets').toJS(),
-				hasVideo,
-				allMetadata,
-				filteredMetadata,
-				audioType,
-			);
+      const bookChapterUrl = getFirstChapterReference(
+        bible.get('filesets').toJS(),
+        hasVideo,
+        allMetadata,
+        filteredMetadata,
+        audioType,
+      );
 
-			// Need to parse out the bookChapterUrl to create the href version for the server
-			// Safe to access 0th element for \w of match since it always returns a string
-			const bookId = bookChapterUrl.match(/\w*/)[0]; // Get first word which is bookId
-			const chapterId = bookChapterUrl.match(/\/\w*/)[0].slice(1); // get second part of url
-			const query =
-				bookChapterUrl.match(/\?.*/) &&
-				bookChapterUrl.match(/\?.*/)[0].replace('?', '&'); // Get any query params at the end
+      // Need to parse out the bookChapterUrl to create the href version for the server
+      // Safe to access 0th element for \w of match since it always returns a string
+      const bookId = bookChapterUrl.match(/\w*/)[0]; // Get first word which is bookId
+      const chapterId = bookChapterUrl.match(/\/\w*/)[0].slice(1); // get second part of url
+      const query =
+        bookChapterUrl.match(/\?.*/) &&
+        bookChapterUrl.match(/\?.*/)[0].replace('?', '&'); // Get any query params at the end
 
-			Router.push(
-				`/app?bibleId=${bible.get(
-					'abbr',
-				)}&bookId=${bookId}&chapter=${chapterId}${query || ''}`,
-				`/bible/${bible.get('abbr')}/${bookChapterUrl}`,
-			);
-		}
+      Router.push(
+        `/app?bibleId=${bible.get(
+          'abbr',
+        )}&bookId=${bookId}&chapter=${chapterId}${query || ''}`,
+        `/bible/${bible.get('abbr')}/${bookChapterUrl}`,
+      );
+    }
 
-		if (bible) {
-			if (audioType) {
-				if (
-					typeof window !== 'undefined' &&
-					(audioType === 'audio' || audioType === 'audio_drama')
-				) {
-					document.cookie = `bible_is_audio_type=${audioType};path=/bible/${bible.get(
-						'abbr',
-					)}`;
-				}
-			}
-			toggleTextSelection();
-		}
-	};
+    if (bible) {
+      if (audioType) {
+        if (
+          typeof window !== 'undefined' &&
+          (audioType === 'audio' || audioType === 'audio_drama')
+        ) {
+          document.cookie = `bible_is_audio_type=${audioType};path=/bible/${bible.get(
+            'abbr',
+          )}`;
+        }
+      }
+      toggleTextSelection();
+    }
+  };
 
-	render() {
-		const { active, loadingVersions } = this.props;
+  render() {
+    const { active, loadingVersions } = this.props;
 
-		return (
-			<div
-				style={{ display: active ? 'block' : 'none' }}
-				className="text-selection-section"
-			>
-				<div className="version-name-list">
-					{loadingVersions ? <LoadingSpinner /> : this.filteredVersionList}
-				</div>
-			</div>
-		);
-	}
+    return (
+      <div
+        style={{ display: active ? 'block' : 'none' }}
+        className="text-selection-section"
+      >
+        <div className="version-name-list">
+          {loadingVersions ? <LoadingSpinner /> : this.filteredVersionList}
+        </div>
+      </div>
+    );
+  }
 }
 
 VersionList.propTypes = {
-	bibles: PropTypes.object,
-	dispatch: PropTypes.func,
-	setActiveText: PropTypes.func,
-	toggleTextSelection: PropTypes.func,
-	activeTextId: PropTypes.string,
-	filterText: PropTypes.string,
-	activeBookId: PropTypes.string,
-	activeChapter: PropTypes.number,
-	active: PropTypes.bool,
-	hasVideo: PropTypes.bool,
-	loadingVersions: PropTypes.bool,
+  bibles: PropTypes.object,
+  dispatch: PropTypes.func,
+  setActiveText: PropTypes.func,
+  toggleTextSelection: PropTypes.func,
+  activeTextId: PropTypes.string,
+  filterText: PropTypes.string,
+  activeBookId: PropTypes.string,
+  activeChapter: PropTypes.number,
+  active: PropTypes.bool,
+  hasVideo: PropTypes.bool,
+  loadingVersions: PropTypes.bool,
 };
 
 function mapDispatchToProps(dispatch) {
-	return {
-		dispatch,
-	};
+  return {
+    dispatch,
+  };
 }
 
 const mapStateToProps = createStructuredSelector({
-	activeBookId: selectActiveBookId(),
-	activeChapter: selectActiveChapter(),
-	hasVideo: selectHasVideo(),
+  activeBookId: selectActiveBookId(),
+  activeChapter: selectActiveChapter(),
+  hasVideo: selectHasVideo(),
 });
 
-const withConnect = connect(mapStateToProps, mapDispatchToProps);
+const withConnect = connect(
+  mapStateToProps,
+  mapDispatchToProps,
+);
 
 export default compose(withConnect)(VersionList);

--- a/app/components/VersionList/index.js
+++ b/app/components/VersionList/index.js
@@ -22,302 +22,272 @@ import { selectHasVideo } from '../../containers/VideoPlayer/selectors';
 import getUrl from '../../utils/hrefLinkOrAsLink';
 
 export class VersionList extends React.PureComponent {
-  get filteredVersionList() {
-    const {
-      bibles,
-      activeTextId,
-      filterText,
-      activeChapter,
-      activeBookId,
-    } = this.props;
-    const filteredBibles = filterText
-      ? bibles?.filter(this.filterFunction)
-      : bibles;
+	get filteredVersionList() {
+		const { bibles, activeTextId, filterText, activeChapter, activeBookId } =
+			this.props;
+		const filteredBibles = filterText
+			? bibles?.filter(this.filterFunction)
+			: bibles;
 
-    const getKey = (bible) => {
-      if (!bible) return '';
-      const abbr = bible.get('abbr');
-      const date = bible.get('date') || '2019';
-      const typeSuffix = bible.get('hasVideo') ? '_video' : '_plain';
-      return abbr + date + typeSuffix;
-    };
+		const getKey = (bible) => {
+			if (!bible) return '';
+			const abbr = bible.get('abbr');
+			const date = bible.get('date') || '2019';
+			const typeSuffix = bible.get('hasVideo') ? '_video' : '_plain';
+			return abbr + date + typeSuffix;
+		};
 
-    // Change the way I figure out if a resource has text or audio
-    // path, key, types, className, text, clickHandler
-    // Set the path to just the bible_id and let app.js handle getting the actual book and chapter needed
-    const scrubbedBibles = filteredBibles?.reduce((acc, bible) => {
-      const item = {
-        path: {
-          textId: bible.get('abbr'),
-          bookId: activeBookId,
-          chapter: activeChapter,
-        },
-        key: getKey(bible),
-        clickHandler: (audioType) => this.handleVersionListClick(bible, audioType),
-        className: bible.get('abbr') === activeTextId ? 'active-version' : '',
-        title: bible.get('name'),
-        text: bible.get('vname') || bible.get('name') || bible.get('abbr'),
-        altText:
-          bible.get('vname') && bible.get('vname') !== bible.get('name')
-            ? bible.get('name')
-            : '',
-        types: bible.get('filesets')
-          ? bible
-            .get('filesets')
-            .reduce((a, c) => ({ ...a, [c.get('type')]: true }), {})
-          : {},
-      };
+		// Change the way I figure out if a resource has text or audio
+		// path, key, types, className, text, clickHandler
+		// Set the path to just the bible_id and let app.js handle getting the actual book and chapter needed
+		const scrubbedBibles = filteredBibles?.reduce((acc, bible) => {
+			const item = {
+				path: {
+					textId: bible.get('abbr'),
+					bookId: activeBookId,
+					chapter: activeChapter,
+				},
+				key: getKey(bible),
+				clickHandler: (audioType) =>
+					this.handleVersionListClick(bible, audioType),
+				className: bible.get('abbr') === activeTextId ? 'active-version' : '',
+				title: bible.get('name'),
+				text: bible.get('vname') || bible.get('name') || bible.get('abbr'),
+				altText:
+					bible.get('vname') && bible.get('vname') !== bible.get('name')
+						? bible.get('name')
+						: '',
+				types: bible.get('filesets')
+					? bible
+							.get('filesets')
+							.reduce((a, c) => ({ ...a, [c.get('type')]: true }), {})
+					: {},
+			};
 
-      acc.push(item);
-      return acc;
-    }, []);
+			acc.push(item);
+			return acc;
+		}, []);
 
-    // When I first get the response from the server with filesets
-    const video = [];
-    const audioAndText = [];
-    const audioOnly = [];
-    const textOnly = [];
+		// When I first get the response from the server with filesets
+		const video = [];
+		const audioAndText = [];
+		const audioOnly = [];
+		const textOnly = [];
 
-    scrubbedBibles?.forEach((b) => {
-      if (b.types.video_stream) {
-        video.push(b);
-      } else if (
-        (b.types.audio_drama || b.types.audio) &&
-        (b.types.text_plain || b.types.text_format)
-      ) {
-        audioAndText.push(b);
-      } else if (b.types.audio_drama || b.types.audio) {
-        audioOnly.push(b);
-      } else {
-        textOnly.push(b);
-      }
-    });
+		scrubbedBibles?.forEach((b) => {
+			if (b.types.video_stream) {
+				video.push(b);
+			} else if (
+				(b.types.audio_drama || b.types.audio) &&
+				(b.types.text_plain || b.types.text_format)
+			) {
+				audioAndText.push(b);
+			} else if (b.types.audio_drama || b.types.audio) {
+				audioOnly.push(b);
+			} else {
+				textOnly.push(b);
+			}
+		});
 
-    const videoComponent = video?.length ? (
-      <div className={'version-list-section'} key={'video'}>
-        <div className={'version-list-section-title'}>
-          <FormattedMessage {...messages.video} />
-        </div>
-        <VersionListSection items={video} />
-      </div>
-    ) : null;
-    const audioAndTextComponent = audioAndText.length ? (
-      <div className={'version-list-section'} key={'audio-and-text'}>
-        <div className={'version-list-section-title'}>
-          <FormattedMessage {...messages.audioAndText} />
-        </div>
-        <VersionListSection items={audioAndText} />
-      </div>
-    ) : null;
-    const audioOnlyComponent = audioOnly.length ? (
-      <div className={'version-list-section'} key={'audio-only'}>
-        <div className={'version-list-section-title'}>
-          <FormattedMessage {...messages.audioOnly} />
-        </div>
-        <VersionListSection items={audioOnly} />
-      </div>
-    ) : null;
-    const textOnlyComponent = textOnly.length ? (
-      <div className={'version-list-section'} key={'text-only'}>
-        <div className={'version-list-section-title'}>
-          <FormattedMessage {...messages.textOnly} />
-        </div>
-        <VersionListSection items={textOnly} />
-      </div>
-    ) : null;
+		const videoComponent = video?.length ? (
+			<div className={'version-list-section'} key={'video'}>
+				<div className={'version-list-section-title'}>
+					<FormattedMessage {...messages.video} />
+				</div>
+				<VersionListSection items={video} />
+			</div>
+		) : null;
+		const audioAndTextComponent = audioAndText.length ? (
+			<div className={'version-list-section'} key={'audio-and-text'}>
+				<div className={'version-list-section-title'}>
+					<FormattedMessage {...messages.audioAndText} />
+				</div>
+				<VersionListSection items={audioAndText} />
+			</div>
+		) : null;
+		const audioOnlyComponent = audioOnly.length ? (
+			<div className={'version-list-section'} key={'audio-only'}>
+				<div className={'version-list-section-title'}>
+					<FormattedMessage {...messages.audioOnly} />
+				</div>
+				<VersionListSection items={audioOnly} />
+			</div>
+		) : null;
+		const textOnlyComponent = textOnly.length ? (
+			<div className={'version-list-section'} key={'text-only'}>
+				<div className={'version-list-section-title'}>
+					<FormattedMessage {...messages.textOnly} />
+				</div>
+				<VersionListSection items={textOnly} />
+			</div>
+		) : null;
 
-    const components = [
-      videoComponent,
-      audioAndTextComponent,
-      audioOnlyComponent,
-      textOnlyComponent,
-    ];
+		const components = [
+			videoComponent,
+			audioAndTextComponent,
+			audioOnlyComponent,
+			textOnlyComponent,
+		];
 
-    if (bibles?.size === 0) {
-      return (
-        <span className="version-item-button">
-          There was an error fetching this resource, an Admin has been notified.
-          We apologize for the inconvenience.
-        </span>
-      );
-    }
+		if (bibles?.size === 0) {
+			return (
+				<span className="version-item-button">
+					There was an error fetching this resource, an Admin has been notified.
+					We apologize for the inconvenience.
+				</span>
+			);
+		}
 
-    return scrubbedBibles?.length ? (
-      components
-    ) : (
-      <span className="version-item-button">
-        There are no matches for your search.
-      </span>
-    );
-  }
+		return scrubbedBibles?.length ? (
+			components
+		) : (
+			<span className="version-item-button">
+				There are no matches for your search.
+			</span>
+		);
+	}
 
-  filterFunction = (bible) => {
-    const lowerCaseText = this.props.filterText.toLowerCase();
-    const properties = ['vname', 'name', 'abbr', 'date'];
+	filterFunction = (bible) => {
+		const lowerCaseText = this.props.filterText.toLowerCase();
+		const properties = ['vname', 'name', 'abbr', 'date'];
 
-    return properties.some((property) => {
-      const propValue = bible.get(property) || '';
-      return propValue.toLowerCase().includes(lowerCaseText);
-    });
-  };
+		return properties.some((property) => {
+			const propValue = bible.get(property) || '';
+			return propValue.toLowerCase().includes(lowerCaseText);
+		});
+	};
 
-  // Make async
-  handleVersionListClick = async (bible, audioType) => {
-    // Figure out correct url here based on session variable value
-    const {
-      toggleTextSelection,
-      setActiveText,
-      activeTextId,
-      activeBookId,
-      activeChapter,
-    } = this.props;
-    const hasVideo = !!bible.get('hasVideo');
+	// Make async
+	handleVersionListClick = async (bible, audioType) => {
+		// Figure out correct url here based on session variable value
+		const { toggleTextSelection, activeTextId, activeBookId, activeChapter } =
+			this.props;
+		const hasVideo = !!bible.get('hasVideo');
 
-    if (bible.get('jesusFilm')) {
-      // If there is a Jesus Film then use alternate navigation logic
-      Router.push(`/jesus-film/${bible.get('iso')}`);
-      toggleTextSelection();
-      // End function early since navigation should have already occurred
-      return;
-    }
-    // If bible id is equal to the active bible id then just return and don't change version
-    if (bible.get('abbr').toLowerCase() === activeTextId.toLowerCase()) {
-      toggleTextSelection();
-      return;
-    }
+		if (bible.get('jesusFilm')) {
+			// If there is a Jesus Film then use alternate navigation logic
+			Router.push(`/jesus-film/${bible.get('iso')}`);
+			toggleTextSelection();
+			// End function early since navigation should have already occurred
+			return;
+		}
+		// If bible id is equal to the active bible id then just return and don't change version
+		if (bible.get('abbr').toLowerCase() === activeTextId.toLowerCase()) {
+			toggleTextSelection();
+			return;
+		}
 
-    if (bible.get('abbr').toLowerCase() !== activeTextId.toLowerCase()) {
-      this.props.dispatch(changeVersion({ state: true }));
-    }
+		if (bible.get('abbr').toLowerCase() !== activeTextId.toLowerCase()) {
+			this.props.dispatch(changeVersion({ state: true }));
+		}
 
-    if (bible) {
-      const filesets = bible
-        .get('filesets')
-        .filter((f) => f.get('type') !== 'app');
+		if (JSON.parse(sessionStorage.getItem('bible_is_maintain_location'))) {
+			Router.push(
+				getUrl({
+					textId: bible.get('abbr'),
+					bookId: activeBookId,
+					chapter: activeChapter,
+					audioType,
+					isHref: true,
+				}),
+				getUrl({
+					textId: bible.get('abbr'),
+					bookId: activeBookId,
+					chapter: activeChapter,
+					audioType,
+					isHref: false,
+				}),
+			);
+		} else {
+			// Find url and push that one
+			const [filteredMetadata, allMetadata] = await getBookMetaData({
+				idsForBookMetadata: bible
+					.get('filesets')
+					.map((set) => [set.get('type'), set.get('id')])
+					.toJS(),
+			});
 
-      if (audioType) {
-        if (
-          typeof window !== 'undefined' &&
-          (audioType === 'audio' || audioType === 'audio_drama')
-        ) {
-          document.cookie = `bible_is_audio_type=${audioType};path=/bible/${bible.get(
-            'abbr',
-          )}`;
-        }
-        setActiveText({
-          textId: bible.get('abbr'),
-          textName:
-            bible.get('vname') || bible.get('name') || bible.get('abbr'),
-          filesets,
-        });
-        toggleTextSelection();
-      } else {
-        setActiveText({
-          textId: bible.get('abbr'),
-          textName:
-            bible.get('vname') || bible.get('name') || bible.get('abbr'),
-          filesets,
-        });
-        toggleTextSelection();
-      }
-    }
+			const bookChapterUrl = getFirstChapterReference(
+				bible.get('filesets').toJS(),
+				hasVideo,
+				allMetadata,
+				filteredMetadata,
+				audioType,
+			);
 
-    if (JSON.parse(sessionStorage.getItem('bible_is_maintain_location'))) {
-      Router.push(
-        getUrl({
-          textId: bible.get('abbr'),
-          bookId: activeBookId,
-          chapter: activeChapter,
-          audioType,
-          isHref: true,
-        }),
-        getUrl({
-          textId: bible.get('abbr'),
-          bookId: activeBookId,
-          chapter: activeChapter,
-          audioType,
-          isHref: false,
-        }),
-      );
-    } else {
-      // Find url and push that one
-      const [filteredMetadata, allMetadata] = await getBookMetaData({
-        idsForBookMetadata: bible
-          .get('filesets')
-          .map((set) => [set.get('type'), set.get('id')])
-          .toJS(),
-      });
+			// Need to parse out the bookChapterUrl to create the href version for the server
+			// Safe to access 0th element for \w of match since it always returns a string
+			const bookId = bookChapterUrl.match(/\w*/)[0]; // Get first word which is bookId
+			const chapterId = bookChapterUrl.match(/\/\w*/)[0].slice(1); // get second part of url
+			const query =
+				bookChapterUrl.match(/\?.*/) &&
+				bookChapterUrl.match(/\?.*/)[0].replace('?', '&'); // Get any query params at the end
 
-      const bookChapterUrl = getFirstChapterReference(
-        bible.get('filesets').toJS(),
-        hasVideo,
-        allMetadata,
-        filteredMetadata,
-        audioType,
-      );
+			Router.push(
+				`/app?bibleId=${bible.get(
+					'abbr',
+				)}&bookId=${bookId}&chapter=${chapterId}${query || ''}`,
+				`/bible/${bible.get('abbr')}/${bookChapterUrl}`,
+			);
+		}
 
-      // Need to parse out the bookChapterUrl to create the href version for the server
-      // Safe to access 0th element for \w of match since it always returns a string
-      const bookId = bookChapterUrl.match(/\w*/)[0]; // Get first word which is bookId
-      const chapterId = bookChapterUrl.match(/\/\w*/)[0].slice(1); // get second part of url
-      const query =
-        bookChapterUrl.match(/\?.*/) &&
-        bookChapterUrl.match(/\?.*/)[0].replace('?', '&'); // Get any query params at the end
+		if (bible) {
+			if (audioType) {
+				if (
+					typeof window !== 'undefined' &&
+					(audioType === 'audio' || audioType === 'audio_drama')
+				) {
+					document.cookie = `bible_is_audio_type=${audioType};path=/bible/${bible.get(
+						'abbr',
+					)}`;
+				}
+			}
+			toggleTextSelection();
+		}
+	};
 
-      Router.push(
-        `/app?bibleId=${bible.get(
-          'abbr',
-        )}&bookId=${bookId}&chapter=${chapterId}${query}`,
-        `/bible/${bible.get('abbr')}/${bookChapterUrl}`,
-      );
-    }
-  };
+	render() {
+		const { active, loadingVersions } = this.props;
 
-  render() {
-    const { active, loadingVersions } = this.props;
-
-    return (
-      <div
-        style={{ display: active ? 'block' : 'none' }}
-        className="text-selection-section"
-      >
-        <div className="version-name-list">
-          {loadingVersions ? <LoadingSpinner /> : this.filteredVersionList}
-        </div>
-      </div>
-    );
-  }
+		return (
+			<div
+				style={{ display: active ? 'block' : 'none' }}
+				className="text-selection-section"
+			>
+				<div className="version-name-list">
+					{loadingVersions ? <LoadingSpinner /> : this.filteredVersionList}
+				</div>
+			</div>
+		);
+	}
 }
 
 VersionList.propTypes = {
-  bibles: PropTypes.object,
-  dispatch: PropTypes.func,
-  setActiveText: PropTypes.func,
-  toggleTextSelection: PropTypes.func,
-  activeTextId: PropTypes.string,
-  filterText: PropTypes.string,
-  activeBookId: PropTypes.string,
-  activeChapter: PropTypes.number,
-  active: PropTypes.bool,
-  hasVideo: PropTypes.bool,
-  loadingVersions: PropTypes.bool,
+	bibles: PropTypes.object,
+	dispatch: PropTypes.func,
+	setActiveText: PropTypes.func,
+	toggleTextSelection: PropTypes.func,
+	activeTextId: PropTypes.string,
+	filterText: PropTypes.string,
+	activeBookId: PropTypes.string,
+	activeChapter: PropTypes.number,
+	active: PropTypes.bool,
+	hasVideo: PropTypes.bool,
+	loadingVersions: PropTypes.bool,
 };
 
 function mapDispatchToProps(dispatch) {
-  return {
-    dispatch,
-  };
+	return {
+		dispatch,
+	};
 }
 
 const mapStateToProps = createStructuredSelector({
-  activeBookId: selectActiveBookId(),
-  activeChapter: selectActiveChapter(),
-  hasVideo: selectHasVideo(),
+	activeBookId: selectActiveBookId(),
+	activeChapter: selectActiveChapter(),
+	hasVideo: selectHasVideo(),
 });
 
-const withConnect = connect(
-  mapStateToProps,
-  mapDispatchToProps,
-);
+const withConnect = connect(mapStateToProps, mapDispatchToProps);
 
 export default compose(withConnect)(VersionList);

--- a/app/containers/AudioPlayer/index.js
+++ b/app/containers/AudioPlayer/index.js
@@ -18,16 +18,16 @@ import SpeedControl from '../../components/SpeedControl';
 import AudioProgressBar from '../../components/AudioProgressBar';
 import VolumeSlider from '../../components/VolumeSlider';
 import makeSelectAudioPlayer, {
-	selectorGenerator,
-	selectAutoPlay,
-	selectPlaybackRate,
-	selectVolume,
+  selectorGenerator,
+  selectAutoPlay,
+  selectPlaybackRate,
+  selectVolume,
 } from './selectors';
 import { selectUserNotes } from '../HomePage/selectors';
 import {
-	setAudioPlayerState,
-	toggleAutoPlay,
-	setChapterTextLoadingState,
+  setAudioPlayerState,
+  toggleAutoPlay,
+  setChapterTextLoadingState,
 } from '../HomePage/actions';
 import reducer from './reducer';
 import messages from './messages';
@@ -44,839 +44,839 @@ import { addFilesetQueryParams, isFileSet } from './helper';
 /* disabled the above eslint config options because you can't add tracks to audio elements */
 
 export class AudioPlayer extends React.Component {
-	// eslint-disable-line react/prefer-stateless-function
-	constructor(props) {
-		super(props);
-		// need to get next and prev audio tracks if I want to enable continuous playing
-		this.state = {
-			playing: false,
-			loadingNextChapter: false,
-			speedControlState: false,
-			volumeSliderState: false,
-			elipsisState: false,
-			duration: 0,
-			currentTime: 0,
-			nextTrack: {
-				index: 0,
-				path: props.audioPaths[0],
-				last: props.audioPaths.length === 0,
-			},
-			clickedPlay: false,
-			wasPlaying: false,
-		};
-	}
+  // eslint-disable-line react/prefer-stateless-function
+  constructor(props) {
+    super(props);
+    // need to get next and prev audio tracks if I want to enable continuous playing
+    this.state = {
+      playing: false,
+      loadingNextChapter: false,
+      speedControlState: false,
+      volumeSliderState: false,
+      elipsisState: false,
+      duration: 0,
+      currentTime: 0,
+      nextTrack: {
+        index: 0,
+        path: props.audioPaths[0],
+        last: props.audioPaths.length === 0,
+      },
+      clickedPlay: false,
+      wasPlaying: false,
+    };
+  }
 
-	componentDidMount() {
-		if (this.props.audioPaths.length) {
-			this.props.audioPaths.forEach((path) => this.preLoadPath(path));
-		}
-		// If auto play is enabled I need to start the player
-		if (this.props.autoPlay) {
-			// Checking User Agent because the canplay event fails silently on mobile apple devices
-			if (
-				navigator?.userAgent &&
-				/iPhone|iPod|iPad/i.test(navigator.userAgent)
-			) {
-				this.audioRef.addEventListener('loadedmetadata', this.autoPlayListener);
-			} else {
-				this.audioRef.addEventListener('canplay', this.autoPlayListener);
-			}
-		}
-		this.audioRef.playbackRate = this.props.playbackRate;
-		// Add all the event listeners I need for the audio player
-		this.audioRef.addEventListener(
-			'durationchange',
-			this.durationChangeEventListener,
-		);
-		this.audioRef.addEventListener('timeupdate', this.timeUpdateEventListener);
-		this.audioRef.addEventListener('seeking', this.seekingEventListener);
-		this.audioRef.addEventListener('seeked', this.seekedEventListener);
-		this.audioRef.addEventListener('ended', this.endedEventListener);
-		this.audioRef.addEventListener('playing', this.playingEventListener);
+  componentDidMount() {
+    if (this.props.audioPaths.length) {
+      this.props.audioPaths.forEach((path) => this.preLoadPath(path));
+    }
+    // If auto play is enabled I need to start the player
+    if (this.props.autoPlay) {
+      // Checking User Agent because the canplay event fails silently on mobile apple devices
+      if (
+        navigator?.userAgent &&
+        /iPhone|iPod|iPad/i.test(navigator.userAgent)
+      ) {
+        this.audioRef.addEventListener('loadedmetadata', this.autoPlayListener);
+      } else {
+        this.audioRef.addEventListener('canplay', this.autoPlayListener);
+      }
+    }
+    this.audioRef.playbackRate = this.props.playbackRate;
+    // Add all the event listeners I need for the audio player
+    this.audioRef.addEventListener(
+      'durationchange',
+      this.durationChangeEventListener,
+    );
+    this.audioRef.addEventListener('timeupdate', this.timeUpdateEventListener);
+    this.audioRef.addEventListener('seeking', this.seekingEventListener);
+    this.audioRef.addEventListener('seeked', this.seekedEventListener);
+    this.audioRef.addEventListener('ended', this.endedEventListener);
+    this.audioRef.addEventListener('playing', this.playingEventListener);
 
-		Router.router.events.on('routeChangeStart', this.handleRouteChange);
-		if (this.props.audioSource) {
-			this.audioRef.load();
-		}
+    Router.router.events.on('routeChangeStart', this.handleRouteChange);
+    if (this.props.audioSource) {
+      this.audioRef.load();
+    }
 
-		if (!this.props.hasAudio && this.props.audioPlayerState) {
-			this.setAudioPlayerState(false);
-		}
+    if (!this.props.hasAudio && this.props.audioPlayerState) {
+      this.setAudioPlayerState(false);
+    }
 
-		this.getAudio(
-			this.props.activeFilesets,
-			this.props.activeBookId,
-			this.props.activeChapter,
-			this.props.audioType,
-		);
-	}
+    this.getAudio(
+      this.props.activeFilesets,
+      this.props.activeBookId,
+      this.props.activeChapter,
+      this.props.audioType,
+    );
+  }
 
-	componentDidUpdate(prevProps) {
-		if (this.props.hasVideo && this.props.videoPlayerOpen) {
-			// this.pauseAudio();
-		}
-		if (
-			prevProps.activeTextId !== this.props.activeTextId ||
-			prevProps.activeBookId !== this.props.activeBookId ||
-			prevProps.activeChapter !== this.props.activeChapter ||
-			prevProps.audioType !== this.props.audioType ||
-			prevProps.verseNumber !== this.props.verseNumber ||
-			!isEqual(prevProps.activeFilesets, this.props.activeFilesets)
-		) {
-			this.getAudio(
-				this.props.activeFilesets,
-				this.props.activeBookId,
-				this.props.activeChapter,
-				this.props.audioType,
-			);
+  componentDidUpdate(prevProps) {
+    if (this.props.hasVideo && this.props.videoPlayerOpen) {
+      // this.pauseAudio();
+    }
+    if (
+      prevProps.activeTextId !== this.props.activeTextId ||
+      prevProps.activeBookId !== this.props.activeBookId ||
+      prevProps.activeChapter !== this.props.activeChapter ||
+      prevProps.audioType !== this.props.audioType ||
+      prevProps.verseNumber !== this.props.verseNumber ||
+      !isEqual(prevProps.activeFilesets, this.props.activeFilesets)
+    ) {
+      this.getAudio(
+        this.props.activeFilesets,
+        this.props.activeBookId,
+        this.props.activeChapter,
+        this.props.audioType,
+      );
 
-			this.setTextLoadingState({ state: false });
-		}
-		if (prevProps.audioSource !== this.props.audioSource) {
-			if (this.props.audioSource && !prevProps.audioSource) {
-				this.setAudioPlayerState(true);
-			}
-			if (this.props.audioSource) {
-				this.setState({ playing: false, loadingNextChapter: false });
-			} else if (
-				prevProps.audioPlayerState &&
-				(!this.props.audioSource || !this.props.hasAudio)
-			) {
-				this.setState({ playing: false }, () =>
-					this.setAudioPlayerState(false),
-				);
-			}
-		}
+      this.setTextLoadingState({ state: false });
+    }
+    if (prevProps.audioSource !== this.props.audioSource) {
+      if (this.props.audioSource && !prevProps.audioSource) {
+        this.setAudioPlayerState(true);
+      }
+      if (this.props.audioSource) {
+        this.setState({ playing: false, loadingNextChapter: false });
+      } else if (
+        prevProps.audioPlayerState &&
+        (!this.props.audioSource || !this.props.hasAudio)
+      ) {
+        this.setState({ playing: false }, () =>
+          this.setAudioPlayerState(false),
+        );
+      }
+    }
 
-		if (this.props.autoPlay) {
-			if (
-				navigator?.userAgent &&
-				/iPhone|iPod|iPad/i.test(navigator.userAgent)
-			) {
-				this.audioRef.addEventListener('loadedmetadata', this.autoPlayListener);
-			} else {
-				this.audioRef.addEventListener('canplay', this.autoPlayListener);
-			}
-		} else if (!this.props.autoPlay) {
-			if (
-				navigator?.userAgent &&
-				/iPhone|iPod|iPad/i.test(navigator.userAgent)
-			) {
-				this.audioRef.removeEventListener(
-					'loadedmetadata',
-					this.autoPlayListener,
-				);
-			} else {
-				this.audioRef.removeEventListener('canplay', this.autoPlayListener);
-			}
-		}
+    if (this.props.autoPlay) {
+      if (
+        navigator?.userAgent &&
+        /iPhone|iPod|iPad/i.test(navigator.userAgent)
+      ) {
+        this.audioRef.addEventListener('loadedmetadata', this.autoPlayListener);
+      } else {
+        this.audioRef.addEventListener('canplay', this.autoPlayListener);
+      }
+    } else if (!this.props.autoPlay) {
+      if (
+        navigator?.userAgent &&
+        /iPhone|iPod|iPad/i.test(navigator.userAgent)
+      ) {
+        this.audioRef.removeEventListener(
+          'loadedmetadata',
+          this.autoPlayListener,
+        );
+      } else {
+        this.audioRef.removeEventListener('canplay', this.autoPlayListener);
+      }
+    }
 
-		if (
-			!isEqual(prevProps.audioPaths, this.props.audioPaths) &&
-			this.props.audioPaths.length
-		) {
-			this.props.audioPaths.forEach((path) => this.preLoadPath(path));
-			this.setState({
-				nextTrack: {
-					index: 0,
-					path: this.props.audioPaths[0],
-					last: this.props.audioPaths.length === 0,
-				},
-			});
-		}
+    if (
+      !isEqual(prevProps.audioPaths, this.props.audioPaths) &&
+      this.props.audioPaths.length
+    ) {
+      this.props.audioPaths.forEach((path) => this.preLoadPath(path));
+      this.setState({
+        nextTrack: {
+          index: 0,
+          path: this.props.audioPaths[0],
+          last: this.props.audioPaths.length === 0,
+        },
+      });
+    }
 
-		// Ensure that the player volume and state volume stay in sync
-		if (this.audioRef) {
-			if (this.audioRef.volume !== prevProps.volume) {
-				this.audioRef.volume = prevProps.volume;
-			}
-			// Ensure that the player playback rate and state playback rate stay in sync
-			if (this.audioRef.playbackRate !== prevProps.playbackRate) {
-				this.audioRef.playbackRate = prevProps.playbackRate;
-			}
-			if (
-				this.state.wasPlaying &&
-				this.props.audioSource !== prevProps.audioSource
-			) {
-				this.playAudio(prevProps.audioSource);
-			}
-		}
-	}
+    // Ensure that the player volume and state volume stay in sync
+    if (this.audioRef) {
+      if (this.audioRef.volume !== prevProps.volume) {
+        this.audioRef.volume = prevProps.volume;
+      }
+      // Ensure that the player playback rate and state playback rate stay in sync
+      if (this.audioRef.playbackRate !== prevProps.playbackRate) {
+        this.audioRef.playbackRate = prevProps.playbackRate;
+      }
+      if (
+        this.state.wasPlaying &&
+        this.props.audioSource !== prevProps.audioSource
+      ) {
+        this.playAudio(prevProps.audioSource);
+      }
+    }
+  }
 
-	componentWillUnmount() {
-		// Removing all the event listeners in the case that this component is unmounted
-		if (navigator?.userAgent && /iPhone|iPod|iPad/i.test(navigator.userAgent)) {
-			this.audioRef.removeEventListener(
-				'loadedmetadata',
-				this.autoPlayListener,
-			);
-		} else {
-			this.audioRef.removeEventListener('canplay', this.autoPlayListener);
-		}
-		this.audioRef.removeEventListener(
-			'durationchange',
-			this.durationChangeEventListener,
-		);
-		this.audioRef.removeEventListener(
-			'timeupdate',
-			this.timeUpdateEventListener,
-		);
-		this.audioRef.removeEventListener('seeking', this.seekingEventListener);
-		this.audioRef.removeEventListener('seeked', this.seekedEventListener);
-		this.audioRef.removeEventListener('ended', this.endedEventListener);
-		this.audioRef.removeEventListener('playing', this.playingEventListener);
+  componentWillUnmount() {
+    // Removing all the event listeners in the case that this component is unmounted
+    if (navigator?.userAgent && /iPhone|iPod|iPad/i.test(navigator.userAgent)) {
+      this.audioRef.removeEventListener(
+        'loadedmetadata',
+        this.autoPlayListener,
+      );
+    } else {
+      this.audioRef.removeEventListener('canplay', this.autoPlayListener);
+    }
+    this.audioRef.removeEventListener(
+      'durationchange',
+      this.durationChangeEventListener,
+    );
+    this.audioRef.removeEventListener(
+      'timeupdate',
+      this.timeUpdateEventListener,
+    );
+    this.audioRef.removeEventListener('seeking', this.seekingEventListener);
+    this.audioRef.removeEventListener('seeked', this.seekedEventListener);
+    this.audioRef.removeEventListener('ended', this.endedEventListener);
+    this.audioRef.removeEventListener('playing', this.playingEventListener);
 
-		Router.router.events.off('routeChangeStart', this.handleRouteChange);
-	}
+    Router.router.events.off('routeChangeStart', this.handleRouteChange);
+  }
 
-	setCurrentTime = (time) => {
-		this.setState(
-			{
-				currentTime: time,
-			},
-			() => {
-				this.audioRef.currentTime = time;
-			},
-		);
-	};
+  setCurrentTime = (time) => {
+    this.setState(
+      {
+        currentTime: time,
+      },
+      () => {
+        this.audioRef.currentTime = time;
+      },
+    );
+  };
 
-	setAudioPlayerRef = (el) => {
-		// eslint-disable-next-line react/no-unused-class-component-methods
-		this.audioPlayerContainer = el;
-	};
+  setAudioPlayerRef = (el) => {
+    // eslint-disable-next-line react/no-unused-class-component-methods
+    this.audioPlayerContainer = el;
+  };
 
-	setSpeedControlState = (state) =>
-		this.setState({
-			speedControlState: state,
-		});
+  setSpeedControlState = (state) =>
+    this.setState({
+      speedControlState: state,
+    });
 
-	setVolumeSliderState = (state) =>
-		this.setState({
-			volumeSliderState: state,
-		});
+  setVolumeSliderState = (state) =>
+    this.setState({
+      volumeSliderState: state,
+    });
 
-	setElipsisState = (state) =>
-		this.setState({
-			elipsisState: state,
-		});
+  setElipsisState = (state) =>
+    this.setState({
+      elipsisState: state,
+    });
 
-	setAudioPlayerState = (state) =>
-		this.props.dispatch(setAudioPlayerState(state));
+  setAudioPlayerState = (state) =>
+    this.props.dispatch(setAudioPlayerState(state));
 
-	setTextLoadingState = (props) =>
-		this.props.dispatch(setChapterTextLoadingState(props));
+  setTextLoadingState = (props) =>
+    this.props.dispatch(setChapterTextLoadingState(props));
 
-	getAudio = async (filesets, bookId, chapter, audioType) => {
-		const audio = await getAudioAsyncCall(filesets, bookId, chapter, audioType);
-		this.props.dispatch({ type: 'loadaudio', ...audio });
-	};
+  getAudio = async (filesets, bookId, chapter, audioType) => {
+    const audio = await getAudioAsyncCall(filesets, bookId, chapter, audioType);
+    this.props.dispatch({ type: 'loadaudio', ...audio });
+  };
 
-	getVolumeSvg(volume) {
-		if (volume <= 0.25) {
-			return <SvgWrapper className={'icon'} fill="#fff" svgid="volume_low" />;
-		} else if (volume <= 0.5) {
-			return <SvgWrapper className={'icon'} fill="#fff" svgid="volume_1" />;
-		} else if (volume <= 0.75) {
-			return <SvgWrapper className={'icon'} fill="#fff" svgid="volume_2" />;
-		}
-		return <SvgWrapper className={'icon'} fill="#fff" svgid="volume_max" />;
-	}
+  getVolumeSvg(volume) {
+    if (volume <= 0.25) {
+      return <SvgWrapper className={'icon'} fill="#fff" svgid="volume_low" />;
+    } else if (volume <= 0.5) {
+      return <SvgWrapper className={'icon'} fill="#fff" svgid="volume_1" />;
+    } else if (volume <= 0.75) {
+      return <SvgWrapper className={'icon'} fill="#fff" svgid="volume_2" />;
+    }
+    return <SvgWrapper className={'icon'} fill="#fff" svgid="volume_max" />;
+  }
 
-	handleRef = (el) => {
-		this.audioRef = el;
-	};
+  handleRef = (el) => {
+    this.audioRef = el;
+  };
 
-	handleRouteChange = () => {
-		this.setCurrentTime(0);
-		this.pauseAudio();
-		this.setState({ loadingNextChapter: true });
-	};
+  handleRouteChange = () => {
+    this.setCurrentTime(0);
+    this.pauseAudio();
+    this.setState({ loadingNextChapter: true });
+  };
 
-	handleBackgroundClick = () => {
-		if (!this.props.audioPlayerState) {
-			this.toggleAudioPlayer();
-		}
-	};
+  handleBackgroundClick = () => {
+    if (!this.props.audioPlayerState) {
+      this.toggleAudioPlayer();
+    }
+  };
 
-	updateVolume = (volume) => {
-		if (volume !== this.props.volume) {
-			document.cookie = `bible_is_volume=${volume};path=/`;
-			this.audioRef.volume = volume;
-			this.props.dispatch(setVolume({ value: volume }));
-		}
-	};
+  updateVolume = (volume) => {
+    if (volume !== this.props.volume) {
+      document.cookie = `bible_is_volume=${volume};path=/`;
+      this.audioRef.volume = volume;
+      this.props.dispatch(setVolume({ value: volume }));
+    }
+  };
 
-	autoPlayListener = () => {
-		const { loadingNextChapter, clickedPlay } = this.state;
-		const { audioPlayerState, changingVersion } = this.props;
+  autoPlayListener = () => {
+    const { loadingNextChapter, clickedPlay } = this.state;
+    const { audioPlayerState, changingVersion } = this.props;
 
-		// can accept event as a parameter
-		if (this.audioRef?.duration) {
-			this.setState({
-				duration: this.audioRef.duration,
-			});
-		}
-		// If the chapter is loaded and the player is open
-		if (
-			!loadingNextChapter &&
-			!changingVersion &&
-			audioPlayerState &&
-			clickedPlay
-		) {
-			this.playAudio();
-		}
-	};
+    // can accept event as a parameter
+    if (this.audioRef?.duration) {
+      this.setState({
+        duration: this.audioRef.duration,
+      });
+    }
+    // If the chapter is loaded and the player is open
+    if (
+      !loadingNextChapter &&
+      !changingVersion &&
+      audioPlayerState &&
+      clickedPlay
+    ) {
+      this.playAudio();
+    }
+  };
 
-	durationChangeEventListener = (e) => {
-		this.setState({
-			duration: e.target.duration,
-		});
-	};
+  durationChangeEventListener = (e) => {
+    this.setState({
+      duration: e.target.duration,
+    });
+  };
 
-	timeUpdateEventListener = (e) => {
-		this.setState({
-			currentTime: e.target.currentTime,
-		});
-	};
+  timeUpdateEventListener = (e) => {
+    this.setState({
+      currentTime: e.target.currentTime,
+    });
+  };
 
-	seekingEventListener = (e) => {
-		this.setState({
-			currentTime: e.target.currentTime,
-		});
-	};
+  seekingEventListener = (e) => {
+    this.setState({
+      currentTime: e.target.currentTime,
+    });
+  };
 
-	seekedEventListener = (e) => {
-		this.setState({
-			currentTime: e.target.currentTime,
-		});
-	};
+  seekedEventListener = (e) => {
+    this.setState({
+      currentTime: e.target.currentTime,
+    });
+  };
 
-	endedEventListener = () => {
-		if (!this.state.nextTrack.last && this.props.audioPaths.length) {
-			this.audioRef.src = this.state.nextTrack.path;
-			this.setState(
-				(prevState) => ({
-					nextTrack: {
-						path: this.props.audioPaths[prevState.nextTrack.index + 1],
-						index: prevState.nextTrack.index + 1,
-						last:
-							this.props.audioPaths.length === prevState.nextTrack.index + 1,
-					},
-					// May need to trigger a play event after the next track loaded in
-				}),
-				() => this.playAudio(),
-			);
-		} else {
-			if (this.props.autoPlay) {
-				this.skipForward();
-			}
-			this.pauseAudio();
-		}
-	};
+  endedEventListener = () => {
+    if (!this.state.nextTrack.last && this.props.audioPaths.length) {
+      this.audioRef.src = this.state.nextTrack.path;
+      this.setState(
+        (prevState) => ({
+          nextTrack: {
+            path: this.props.audioPaths[prevState.nextTrack.index + 1],
+            index: prevState.nextTrack.index + 1,
+            last:
+              this.props.audioPaths.length === prevState.nextTrack.index + 1,
+          },
+          // May need to trigger a play event after the next track loaded in
+        }),
+        () => this.playAudio(),
+      );
+    } else {
+      if (this.props.autoPlay) {
+        this.skipForward();
+      }
+      this.pauseAudio();
+    }
+  };
 
-	preLoadPath = (path) => {
-		const audio = new Audio();
-		audio.src = path;
-	};
+  preLoadPath = (path) => {
+    const audio = new Audio();
+    audio.src = path;
+  };
 
-	playingEventListener = (e) => {
-		if (this.state.playing && e.target.paused) {
-			this.setState({
-				playing: false,
-			});
-		} else if (!this.state.playing && !e.target.paused) {
-			this.setState({
-				playing: true,
-			});
-		}
-	};
+  playingEventListener = (e) => {
+    if (this.state.playing && e.target.paused) {
+      this.setState({
+        playing: false,
+      });
+    } else if (!this.state.playing && !e.target.paused) {
+      this.setState({
+        playing: true,
+      });
+    }
+  };
 
-	pauseAudio = () => {
-		this.audioRef.pause();
-		this.setState({
-			playing: false,
-		});
-	};
+  pauseAudio = () => {
+    this.audioRef.pause();
+    this.setState({
+      playing: false,
+    });
+  };
 
-	playFile(video) {
-		const promise = video.play();
-		if (promise !== undefined) {
-			promise
-				.then(() => {
-					// Autoplay started
-				})
-				.catch(() => {
-					// Autoplay was prevented.
-					video.play();
-				});
-		}
-	}
+  playFile(video) {
+    const promise = video.play();
+    if (promise !== undefined) {
+      promise
+        .then(() => {
+          // Autoplay started
+        })
+        .catch(() => {
+          // Autoplay was prevented.
+          video.play();
+        });
+    }
+  }
 
-	playAudioOnChrome(audioSource) {
-		if (!audioSource) {
-			return;
-		}
-		const hls = new Hls();
-		const video = this.audioRef;
-		// bind them together
-		hls.on(Hls.Events.MEDIA_ATTACHED, () => {
-			const parsedSource = addFilesetQueryParams(audioSource);
-			hls.loadSource(parsedSource);
-		});
-		hls.on(Hls.Events.MANIFEST_PARSED, () => {
-			this.playFile(video);
-		});
-		hls.attachMedia(video);
-	}
+  playAudioOnChrome(audioSource) {
+    if (!audioSource) {
+      return;
+    }
+    const hls = new Hls();
+    const video = this.audioRef;
+    // bind them together
+    hls.on(Hls.Events.MEDIA_ATTACHED, () => {
+      const parsedSource = addFilesetQueryParams(audioSource);
+      hls.loadSource(parsedSource);
+    });
+    hls.on(Hls.Events.MANIFEST_PARSED, () => {
+      this.playFile(video);
+    });
+    hls.attachMedia(video);
+  }
 
-	playAudioOnSafari = () => {
-		const { loadingNextChapter, currentTime } = this.state;
+  playAudioOnSafari = () => {
+    const { loadingNextChapter, currentTime } = this.state;
 
-		if (loadingNextChapter) {
-			return;
-		}
-		const playPromise = this.audioRef.play();
-		// All modern browsers return a promise
-		if (this.props.videoPlayerOpen && this.props.hasVideo) {
-			this.pauseAudio();
-			return;
-		}
-		// This is only because IE doesn't return a promise
-		if (playPromise) {
-			playPromise
-				.then(() => {
-					if (currentTime !== this.audioRef.currentTime) {
-						this.audioRef.currentTime = currentTime;
-					}
-					this.setState({
-						playing: true,
-						clickedPlay: true,
-					});
-				})
-				.catch((err) => {
-					if (process.env.NODE_ENV !== 'production') {
-						/* eslint-disable no-console */
-						console.error('Error with playing audio: ', err);
-						/* eslint-enable no-console */
-					}
-				});
-		} else {
-			// This is so IE will still show the svg for the pause button and such
-			if (currentTime !== this.audioRef.currentTime) {
-				this.audioRef.currentTime = currentTime;
-			}
-			this.setState({
-				playing: true,
-				clickedPlay: true,
-			});
-		}
-	};
+    if (loadingNextChapter) {
+      return;
+    }
+    const playPromise = this.audioRef.play();
+    // All modern browsers return a promise
+    if (this.props.videoPlayerOpen && this.props.hasVideo) {
+      this.pauseAudio();
+      return;
+    }
+    // This is only because IE doesn't return a promise
+    if (playPromise) {
+      playPromise
+        .then(() => {
+          if (currentTime !== this.audioRef.currentTime) {
+            this.audioRef.currentTime = currentTime;
+          }
+          this.setState({
+            playing: true,
+            clickedPlay: true,
+          });
+        })
+        .catch((err) => {
+          if (process.env.NODE_ENV !== 'production') {
+            /* eslint-disable no-console */
+            console.error('Error with playing audio: ', err);
+            /* eslint-enable no-console */
+          }
+        });
+    } else {
+      // This is so IE will still show the svg for the pause button and such
+      if (currentTime !== this.audioRef.currentTime) {
+        this.audioRef.currentTime = currentTime;
+      }
+      this.setState({
+        playing: true,
+        clickedPlay: true,
+      });
+    }
+  };
 
-	playAudio(audioSource) {
-		if (!isFileSet(audioSource)) {
-			this.playAudioOnSafari();
-		} else {
-			this.playAudioOnChrome(audioSource);
-		}
-	}
+  playAudio(audioSource) {
+    if (!isFileSet(audioSource)) {
+      this.playAudioOnSafari();
+    } else {
+      this.playAudioOnChrome(audioSource);
+    }
+  }
 
-	updatePlayerSpeed = (rate) => {
-		if (this.props.playbackRate !== rate) {
-			document.cookie = `bible_is_playbackrate=${JSON.stringify(rate)};path=/`;
-			this.audioRef.playbackRate = rate;
-			// set playback
-			this.props.dispatch(setPlaybackRate({ value: rate }));
-		}
-	};
+  updatePlayerSpeed = (rate) => {
+    if (this.props.playbackRate !== rate) {
+      document.cookie = `bible_is_playbackrate=${JSON.stringify(rate)};path=/`;
+      this.audioRef.playbackRate = rate;
+      // set playback
+      this.props.dispatch(setPlaybackRate({ value: rate }));
+    }
+  };
 
-	skipForward = () => {
-		this.setCurrentTime(0);
-		this.setState(
-			(oldState) => ({
-				wasPlaying: oldState.playing,
-				playing: false,
-				loadingNextChapter: true,
-			}),
-			() => {
-				Router.push(
-					getNextChapterUrl({
-						books: this.props.books,
-						chapter: this.props.activeChapter,
-						bookId: this.props.activeBookId.toLowerCase(),
-						textId: this.props.activeTextId.toLowerCase(),
-						verseNumber: this.props.verseNumber,
-						text: this.props.textData.text,
-						audioType: this.props.audioType,
-						isHref: true,
-					}),
-					getNextChapterUrl({
-						books: this.props.books,
-						chapter: this.props.activeChapter,
-						bookId: this.props.activeBookId.toLowerCase(),
-						textId: this.props.activeTextId.toLowerCase(),
-						verseNumber: this.props.verseNumber,
-						text: this.props.textData.text,
-						audioType: this.props.audioType,
-						isHref: false,
-					}),
-				);
-			},
-		);
-		this.pauseAudio();
-	};
+  skipForward = () => {
+    this.setCurrentTime(0);
+    this.setState(
+      (oldState) => ({
+        wasPlaying: oldState.playing,
+        playing: false,
+        loadingNextChapter: true,
+      }),
+      () => {
+        Router.push(
+          getNextChapterUrl({
+            books: this.props.books,
+            chapter: this.props.activeChapter,
+            bookId: this.props.activeBookId.toLowerCase(),
+            textId: this.props.activeTextId.toLowerCase(),
+            verseNumber: this.props.verseNumber,
+            text: this.props.textData.text,
+            audioType: this.props.audioType,
+            isHref: true,
+          }),
+          getNextChapterUrl({
+            books: this.props.books,
+            chapter: this.props.activeChapter,
+            bookId: this.props.activeBookId.toLowerCase(),
+            textId: this.props.activeTextId.toLowerCase(),
+            verseNumber: this.props.verseNumber,
+            text: this.props.textData.text,
+            audioType: this.props.audioType,
+            isHref: false,
+          }),
+        );
+      },
+    );
+    this.pauseAudio();
+  };
 
-	skipBack = () => {
-		this.setCurrentTime(0);
-		this.setState(
-			(oldState) => ({
-				wasPlaying: oldState.playing,
-				playing: false,
-				loadingNextChapter: true,
-			}),
-			() => {
-				Router.push(
-					getPreviousChapterUrl({
-						books: this.props.books,
-						chapter: this.props.activeChapter,
-						bookId: this.props.activeBookId.toLowerCase(),
-						textId: this.props.activeTextId.toLowerCase(),
-						verseNumber: this.props.verseNumber,
-						text: this.props.textData.text,
-						audioType: this.props.audioType,
-						isHref: true,
-					}),
-					getPreviousChapterUrl({
-						books: this.props.books,
-						chapter: this.props.activeChapter,
-						bookId: this.props.activeBookId.toLowerCase(),
-						textId: this.props.activeTextId.toLowerCase(),
-						verseNumber: this.props.verseNumber,
-						text: this.props.textData.text,
-						audioType: this.props.audioType,
-						isHref: false,
-					}),
-				);
-			},
-		);
-		this.pauseAudio();
-	};
+  skipBack = () => {
+    this.setCurrentTime(0);
+    this.setState(
+      (oldState) => ({
+        wasPlaying: oldState.playing,
+        playing: false,
+        loadingNextChapter: true,
+      }),
+      () => {
+        Router.push(
+          getPreviousChapterUrl({
+            books: this.props.books,
+            chapter: this.props.activeChapter,
+            bookId: this.props.activeBookId.toLowerCase(),
+            textId: this.props.activeTextId.toLowerCase(),
+            verseNumber: this.props.verseNumber,
+            text: this.props.textData.text,
+            audioType: this.props.audioType,
+            isHref: true,
+          }),
+          getPreviousChapterUrl({
+            books: this.props.books,
+            chapter: this.props.activeChapter,
+            bookId: this.props.activeBookId.toLowerCase(),
+            textId: this.props.activeTextId.toLowerCase(),
+            verseNumber: this.props.verseNumber,
+            text: this.props.textData.text,
+            audioType: this.props.audioType,
+            isHref: false,
+          }),
+        );
+      },
+    );
+    this.pauseAudio();
+  };
 
-	toggleAudioPlayer = () => {
-		if (this.props.audioSource && this.props.hasAudio) {
-			this.setAudioPlayerState(!this.props.audioPlayerState);
-		}
-	};
+  toggleAudioPlayer = () => {
+    if (this.props.audioSource && this.props.hasAudio) {
+      this.setAudioPlayerState(!this.props.audioPlayerState);
+    }
+  };
 
-	handleAutoPlayChange = (e) => {
-		this.props.dispatch(toggleAutoPlay({ state: e.target.checked }));
-	};
+  handleAutoPlayChange = (e) => {
+    this.props.dispatch(toggleAutoPlay({ state: e.target.checked }));
+  };
 
-	// Simpler to close all modals than to try and figure out which one to close
-	closeModals = ({ speed, volume }) => {
-		if (speed === 'speed') {
-			this.setState({
-				speedControlState: false,
-			});
-		} else if (volume === 'volume') {
-			this.setState({
-				volumeSliderState: false,
-			});
-		} else {
-			this.setState({
-				volumeSliderState: false,
-				speedControlState: false,
-				elipsisState: false,
-			});
-		}
-	};
+  // Simpler to close all modals than to try and figure out which one to close
+  closeModals = ({ speed, volume }) => {
+    if (speed === 'speed') {
+      this.setState({
+        speedControlState: false,
+      });
+    } else if (volume === 'volume') {
+      this.setState({
+        volumeSliderState: false,
+      });
+    } else {
+      this.setState({
+        volumeSliderState: false,
+        speedControlState: false,
+        elipsisState: false,
+      });
+    }
+  };
 
-	pauseIcon = (
-		<div
-			id={'pause-audio'}
-			onClick={() => {
-				this.setState({ wasPlaying: false });
-				this.pauseAudio();
-			}}
-			className={'icon-wrap'}
-			title={messages.pauseTitle.defaultMessage}
-		>
-			<SvgWrapper className="svgitem icon" fill="#fff" svgid="pause" />
-			<FormattedMessage {...messages.pause} />
-		</div>
-	);
+  pauseIcon = (
+    <div
+      id={'pause-audio'}
+      onClick={() => {
+        this.setState({ wasPlaying: false });
+        this.pauseAudio();
+      }}
+      className={'icon-wrap'}
+      title={messages.pauseTitle.defaultMessage}
+    >
+      <SvgWrapper className="svgitem icon" fill="#fff" svgid="pause" />
+      <FormattedMessage {...messages.pause} />
+    </div>
+  );
 
-	playIcon = () => (
-		<div
-			id={'play-audio'}
-			onClick={() => {
-				this.playAudio(this.props.audioSource);
-			}}
-			className={`icon-wrap ${
-				(this.state.loadingNextChapter || this.props.changingVersion) &&
-				'audio-player-play-disabled'
-			}`}
-			title={messages.playTitle.defaultMessage}
-		>
-			<SvgWrapper className="svgitem icon" svgid="play" />
-			<FormattedMessage {...messages.play} />
-		</div>
-	);
+  playIcon = () => (
+    <div
+      id={'play-audio'}
+      onClick={() => {
+        this.playAudio(this.props.audioSource);
+      }}
+      className={`icon-wrap ${
+        (this.state.loadingNextChapter || this.props.changingVersion) &&
+        'audio-player-play-disabled'
+      }`}
+      title={messages.playTitle.defaultMessage}
+    >
+      <SvgWrapper className="svgitem icon" svgid="play" />
+      <FormattedMessage {...messages.play} />
+    </div>
+  );
 
-	render() {
-		const {
-			audioSource: source,
-			hasAudio,
-			audioPlayerState,
-			videoPlayerOpen,
-			hasVideo,
-			audioType,
-			autoPlay,
-			volume,
-			playbackRate,
-			activeTextId,
-		} = this.props;
+  render() {
+    const {
+      audioSource: source,
+      hasAudio,
+      audioPlayerState,
+      videoPlayerOpen,
+      hasVideo,
+      audioType,
+      autoPlay,
+      volume,
+      playbackRate,
+      activeTextId,
+    } = this.props;
 
-		return (
-			<>
-				<div
-					className={getClassNamesForAudioHandle({
-						audioSource: source,
-						hasAudio,
-						hasVideo,
-						audioPlayerState,
-						videoPlayerOpen,
-					})}
-					onClick={(e) => {
-						e.stopPropagation();
-						this.toggleAudioPlayer();
-					}}
-				>
-					<SvgWrapper
-						width="26px"
-						height="26px"
-						className={
-							(!videoPlayerOpen || !hasVideo) && audioPlayerState
-								? 'audio-gripper'
-								: 'audio-gripper closed'
-						}
-						style={{ cursor: source ? 'pointer' : 'inherit' }}
-						svgid="arrow_down"
-					/>
-				</div>
-				<div
-					className={getClassNamesForAudioBackground({
-						audioSource: source,
-						hasAudio,
-						hasVideo,
-						audioPlayerState,
-						videoPlayerOpen,
-					})}
-					ref={this.setAudioPlayerRef}
-					onClick={this.handleBackgroundClick}
-				>
-					<div
-						className={
-							audioPlayerState &&
-							(!videoPlayerOpen || !hasVideo) &&
-							hasAudio &&
-							source !== ''
-								? 'audio-player-container'
-								: 'audio-player-container closed'
-						}
-					>
-						<NewChapterArrow
-							clickHandler={this.skipBack}
-							getNewUrl={getPreviousChapterUrl}
-							urlProps={{
-								books: this.props.books,
-								chapter: this.props.activeChapter,
-								bookId: this.props.activeBookId.toLowerCase(),
-								textId: activeTextId.toLowerCase(),
-								verseNumber: this.props.verseNumber,
-								text: this.props.textData.text,
-								audioType,
-							}}
-							disabled={false}
-							svgid={'previous'}
-							svgClasses={'svgitem icon'}
-							containerClasses={'icon-wrap'}
-							id={'previous-chapter-audio'}
-							title={messages.prevTitle.defaultMessage}
-							textProps={messages.prev}
-						/>
-						{this.state.playing ? this.pauseIcon : this.playIcon()}
-						<NewChapterArrow
-							clickHandler={this.skipForward}
-							getNewUrl={getNextChapterUrl}
-							urlProps={{
-								books: this.props.books,
-								chapter: this.props.activeChapter,
-								bookId: this.props.activeBookId.toLowerCase(),
-								textId: activeTextId.toLowerCase(),
-								verseNumber: this.props.verseNumber,
-								text: this.props.textData.text,
-								audioType,
-							}}
-							disabled={false}
-							svgid={'next'}
-							svgClasses={'svgitem icon'}
-							containerClasses={'icon-wrap'}
-							id={'next-chapter-audio'}
-							title={messages.nextTitle.defaultMessage}
-							textProps={messages.next}
-						/>
-						<AudioProgressBar
-							setCurrentTime={this.setCurrentTime}
-							duration={this.state.duration}
-							currentTime={this.state.currentTime}
-						/>
-						<div
-							id={'autoplay-wrap'}
-							className={'icon-wrap'}
-							title={messages.autoplayTitle.defaultMessage}
-						>
-							<input
-								id={'autoplay'}
-								className={'custom-checkbox'}
-								type="checkbox"
-								onChange={this.handleAutoPlayChange}
-								defaultChecked={autoPlay}
-							/>
-							<label htmlFor={'autoplay'}>
-								<FormattedMessage {...messages.autoplay} />
-							</label>
-						</div>
-						<div id="volume-wrap" className={'icon-wrap'}>
-							<div
-								title={messages.volumeTitle.defaultMessage}
-								className={
-									this.state.volumeSliderState ? 'item active' : 'item'
-								}
-								id={'volume-button'}
-								onTouchEnd={(e) => {
-									e.preventDefault();
-									if (!this.state.volumeSliderState) {
-										this.setVolumeSliderState(true);
-									}
-									this.setSpeedControlState(false);
-									this.setElipsisState(false);
-								}}
-								onClick={() => {
-									if (!this.state.volumeSliderState) {
-										this.setVolumeSliderState(true);
-									}
-									this.setSpeedControlState(false);
-									this.setElipsisState(false);
-								}}
-							>
-								{this.getVolumeSvg(volume)}
-								<FormattedMessage {...messages.volume} />
-							</div>
-							<VolumeSlider
-								active={this.state.volumeSliderState}
-								onCloseFunction={this.closeModals}
-								updateVolume={this.updateVolume}
-								volume={volume}
-							/>
-						</div>
-						<div id="speed-wrap" className={'icon-wrap'}>
-							<div
-								title={messages.speedTitle.defaultMessage}
-								id={'speed-button'}
-								className={
-									this.state.speedControlState ? 'item active' : 'item'
-								}
-								onTouchEnd={(e) => {
-									e.preventDefault();
-									if (!this.state.speedControlState) {
-										this.setSpeedControlState(true);
-									}
-									this.setElipsisState(false);
-									this.setVolumeSliderState(false);
-								}}
-								onClick={() => {
-									if (!this.state.speedControlState) {
-										this.setSpeedControlState(true);
-									}
-									this.setElipsisState(false);
-									this.setVolumeSliderState(false);
-								}}
-							>
-								<PlaybackRateSvg playbackRate={playbackRate} />
-								<FormattedMessage {...messages.speed} />
-							</div>
-							<SpeedControl
-								active={this.state.speedControlState}
-								options={[0.75, 1, 1.25, 1.5, 2]}
-								onCloseFunction={this.closeModals}
-								setSpeed={this.updatePlayerSpeed}
-								playbackRate={playbackRate}
-							/>
-						</div>
-					</div>
-					<video
-						ref={this.handleRef}
-						className="audio-player"
-						src={`${addFilesetQueryParams(source)}` || '_'}
-						data-src={`source-${addFilesetQueryParams(source)}-${source}`}
-					/>
-				</div>
-			</>
-		);
-	}
+    return (
+      <>
+        <div
+          className={getClassNamesForAudioHandle({
+            audioSource: source,
+            hasAudio,
+            hasVideo,
+            audioPlayerState,
+            videoPlayerOpen,
+          })}
+          onClick={(e) => {
+            e.stopPropagation();
+            this.toggleAudioPlayer();
+          }}
+        >
+          <SvgWrapper
+            width="26px"
+            height="26px"
+            className={
+              (!videoPlayerOpen || !hasVideo) && audioPlayerState
+                ? 'audio-gripper'
+                : 'audio-gripper closed'
+            }
+            style={{ cursor: source ? 'pointer' : 'inherit' }}
+            svgid="arrow_down"
+          />
+        </div>
+        <div
+          className={getClassNamesForAudioBackground({
+            audioSource: source,
+            hasAudio,
+            hasVideo,
+            audioPlayerState,
+            videoPlayerOpen,
+          })}
+          ref={this.setAudioPlayerRef}
+          onClick={this.handleBackgroundClick}
+        >
+          <div
+            className={
+              audioPlayerState &&
+              (!videoPlayerOpen || !hasVideo) &&
+              hasAudio &&
+              source !== ''
+                ? 'audio-player-container'
+                : 'audio-player-container closed'
+            }
+          >
+            <NewChapterArrow
+              clickHandler={this.skipBack}
+              getNewUrl={getPreviousChapterUrl}
+              urlProps={{
+                books: this.props.books,
+                chapter: this.props.activeChapter,
+                bookId: this.props.activeBookId.toLowerCase(),
+                textId: activeTextId.toLowerCase(),
+                verseNumber: this.props.verseNumber,
+                text: this.props.textData.text,
+                audioType,
+              }}
+              disabled={false}
+              svgid={'previous'}
+              svgClasses={'svgitem icon'}
+              containerClasses={'icon-wrap'}
+              id={'previous-chapter-audio'}
+              title={messages.prevTitle.defaultMessage}
+              textProps={messages.prev}
+            />
+            {this.state.playing ? this.pauseIcon : this.playIcon()}
+            <NewChapterArrow
+              clickHandler={this.skipForward}
+              getNewUrl={getNextChapterUrl}
+              urlProps={{
+                books: this.props.books,
+                chapter: this.props.activeChapter,
+                bookId: this.props.activeBookId.toLowerCase(),
+                textId: activeTextId.toLowerCase(),
+                verseNumber: this.props.verseNumber,
+                text: this.props.textData.text,
+                audioType,
+              }}
+              disabled={false}
+              svgid={'next'}
+              svgClasses={'svgitem icon'}
+              containerClasses={'icon-wrap'}
+              id={'next-chapter-audio'}
+              title={messages.nextTitle.defaultMessage}
+              textProps={messages.next}
+            />
+            <AudioProgressBar
+              setCurrentTime={this.setCurrentTime}
+              duration={this.state.duration}
+              currentTime={this.state.currentTime}
+            />
+            <div
+              id={'autoplay-wrap'}
+              className={'icon-wrap'}
+              title={messages.autoplayTitle.defaultMessage}
+            >
+              <input
+                id={'autoplay'}
+                className={'custom-checkbox'}
+                type="checkbox"
+                onChange={this.handleAutoPlayChange}
+                defaultChecked={autoPlay}
+              />
+              <label htmlFor={'autoplay'}>
+                <FormattedMessage {...messages.autoplay} />
+              </label>
+            </div>
+            <div id="volume-wrap" className={'icon-wrap'}>
+              <div
+                title={messages.volumeTitle.defaultMessage}
+                className={
+                  this.state.volumeSliderState ? 'item active' : 'item'
+                }
+                id={'volume-button'}
+                onTouchEnd={(e) => {
+                  e.preventDefault();
+                  if (!this.state.volumeSliderState) {
+                    this.setVolumeSliderState(true);
+                  }
+                  this.setSpeedControlState(false);
+                  this.setElipsisState(false);
+                }}
+                onClick={() => {
+                  if (!this.state.volumeSliderState) {
+                    this.setVolumeSliderState(true);
+                  }
+                  this.setSpeedControlState(false);
+                  this.setElipsisState(false);
+                }}
+              >
+                {this.getVolumeSvg(volume)}
+                <FormattedMessage {...messages.volume} />
+              </div>
+              <VolumeSlider
+                active={this.state.volumeSliderState}
+                onCloseFunction={this.closeModals}
+                updateVolume={this.updateVolume}
+                volume={volume}
+              />
+            </div>
+            <div id="speed-wrap" className={'icon-wrap'}>
+              <div
+                title={messages.speedTitle.defaultMessage}
+                id={'speed-button'}
+                className={
+                  this.state.speedControlState ? 'item active' : 'item'
+                }
+                onTouchEnd={(e) => {
+                  e.preventDefault();
+                  if (!this.state.speedControlState) {
+                    this.setSpeedControlState(true);
+                  }
+                  this.setElipsisState(false);
+                  this.setVolumeSliderState(false);
+                }}
+                onClick={() => {
+                  if (!this.state.speedControlState) {
+                    this.setSpeedControlState(true);
+                  }
+                  this.setElipsisState(false);
+                  this.setVolumeSliderState(false);
+                }}
+              >
+                <PlaybackRateSvg playbackRate={playbackRate} />
+                <FormattedMessage {...messages.speed} />
+              </div>
+              <SpeedControl
+                active={this.state.speedControlState}
+                options={[0.75, 1, 1.25, 1.5, 2]}
+                onCloseFunction={this.closeModals}
+                setSpeed={this.updatePlayerSpeed}
+                playbackRate={playbackRate}
+              />
+            </div>
+          </div>
+          <video
+            ref={this.handleRef}
+            className="audio-player"
+            src={`${addFilesetQueryParams(source)}` || '_'}
+            data-src={`source-${addFilesetQueryParams(source)}-${source}`}
+          />
+        </div>
+      </>
+    );
+  }
 }
 
 AudioPlayer.propTypes = {
-	textData: PropTypes.object,
-	audioSource: PropTypes.string,
-	audioType: PropTypes.string,
-	activeBookId: PropTypes.string,
-	activeTextId: PropTypes.string.isRequired,
-	verseNumber: PropTypes.string,
-	dispatch: PropTypes.func,
-	hasAudio: PropTypes.bool,
-	hasVideo: PropTypes.bool,
-	autoPlay: PropTypes.bool,
-	videoPlayerOpen: PropTypes.bool,
-	isScrollingDown: PropTypes.bool,
-	changingVersion: PropTypes.bool,
-	audioPlayerState: PropTypes.bool.isRequired,
-	audioPaths: PropTypes.array,
-	activeFilesets: PropTypes.array,
-	books: PropTypes.array,
-	activeChapter: PropTypes.number,
-	playbackRate: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
-	volume: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+  textData: PropTypes.object,
+  audioSource: PropTypes.string,
+  audioType: PropTypes.string,
+  activeBookId: PropTypes.string,
+  activeTextId: PropTypes.string.isRequired,
+  verseNumber: PropTypes.string,
+  dispatch: PropTypes.func,
+  hasAudio: PropTypes.bool,
+  hasVideo: PropTypes.bool,
+  autoPlay: PropTypes.bool,
+  videoPlayerOpen: PropTypes.bool,
+  isScrollingDown: PropTypes.bool,
+  changingVersion: PropTypes.bool,
+  audioPlayerState: PropTypes.bool.isRequired,
+  audioPaths: PropTypes.array,
+  activeFilesets: PropTypes.array,
+  books: PropTypes.array,
+  activeChapter: PropTypes.number,
+  playbackRate: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+  volume: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
 };
 
 const mapStateToProps = createStructuredSelector({
-	// Audio Domain
-	audioplayer: makeSelectAudioPlayer(),
-	// Settings Domain
-	autoPlay: selectAutoPlay(),
-	playbackRate: selectPlaybackRate(),
-	volume: selectVolume(),
-	// Homepage Domain
-	books: selectorGenerator('books', 'homepage'),
-	hasAudio: selectorGenerator('hasAudio', 'homepage'),
-	hasVideo: selectorGenerator('hasVideo', 'homepage'),
-	audioSource: selectorGenerator('audioSource', 'homepage'),
-	audioPaths: selectorGenerator('audioPaths', 'homepage'),
-	activeFilesets: selectorGenerator('activeFilesets', 'homepage'),
-	videoPlayerOpen: selectorGenerator('videoPlayerOpen', 'homepage'),
-	audioPlayerState: selectorGenerator('audioPlayerState', 'homepage'),
-	activeBookId: selectorGenerator('activeBookId', 'homepage'),
-	activeTextId: selectorGenerator('activeTextId', 'homepage'),
-	activeChapter: selectorGenerator('activeChapter', 'homepage'),
-	changingVersion: selectorGenerator('changingVersion', 'homepage'),
-	// Other Selectors
-	textData: selectUserNotes(),
+  // Audio Domain
+  audioplayer: makeSelectAudioPlayer(),
+  // Settings Domain
+  autoPlay: selectAutoPlay(),
+  playbackRate: selectPlaybackRate(),
+  volume: selectVolume(),
+  // Homepage Domain
+  books: selectorGenerator('books', 'homepage'),
+  hasAudio: selectorGenerator('hasAudio', 'homepage'),
+  hasVideo: selectorGenerator('hasVideo', 'homepage'),
+  audioSource: selectorGenerator('audioSource', 'homepage'),
+  audioPaths: selectorGenerator('audioPaths', 'homepage'),
+  activeFilesets: selectorGenerator('activeFilesets', 'homepage'),
+  videoPlayerOpen: selectorGenerator('videoPlayerOpen', 'homepage'),
+  audioPlayerState: selectorGenerator('audioPlayerState', 'homepage'),
+  activeBookId: selectorGenerator('activeBookId', 'homepage'),
+  activeTextId: selectorGenerator('activeTextId', 'homepage'),
+  activeChapter: selectorGenerator('activeChapter', 'homepage'),
+  changingVersion: selectorGenerator('changingVersion', 'homepage'),
+  // Other Selectors
+  textData: selectUserNotes(),
 });
 
 function mapDispatchToProps(dispatch) {
-	return {
-		dispatch,
-	};
+  return {
+    dispatch,
+  };
 }
 
 const withConnect = connect(mapStateToProps, mapDispatchToProps);

--- a/app/containers/AudioPlayer/index.js
+++ b/app/containers/AudioPlayer/index.js
@@ -18,13 +18,17 @@ import SpeedControl from '../../components/SpeedControl';
 import AudioProgressBar from '../../components/AudioProgressBar';
 import VolumeSlider from '../../components/VolumeSlider';
 import makeSelectAudioPlayer, {
-  selectorGenerator,
-  selectAutoPlay,
-  selectPlaybackRate,
-  selectVolume,
+	selectorGenerator,
+	selectAutoPlay,
+	selectPlaybackRate,
+	selectVolume,
 } from './selectors';
 import { selectUserNotes } from '../HomePage/selectors';
-import { setAudioPlayerState, toggleAutoPlay } from '../HomePage/actions';
+import {
+	setAudioPlayerState,
+	toggleAutoPlay,
+	setChapterTextLoadingState,
+} from '../HomePage/actions';
 import reducer from './reducer';
 import messages from './messages';
 import getNextChapterUrl from '../../utils/getNextChapterUrl';
@@ -40,848 +44,843 @@ import { addFilesetQueryParams, isFileSet } from './helper';
 /* disabled the above eslint config options because you can't add tracks to audio elements */
 
 export class AudioPlayer extends React.Component {
-  // eslint-disable-line react/prefer-stateless-function
-  constructor(props) {
-    super(props);
-    // need to get next and prev audio tracks if I want to enable continuous playing
-    this.state = {
-      playing: false,
-      loadingNextChapter: false,
-      speedControlState: false,
-      volumeSliderState: false,
-      elipsisState: false,
-      duration: 0,
-      currentTime: 0,
-      nextTrack: {
-        index: 0,
-        path: props.audioPaths[0],
-        last: props.audioPaths.length === 0,
-      },
-      clickedPlay: false,
-    };
-  }
+	// eslint-disable-line react/prefer-stateless-function
+	constructor(props) {
+		super(props);
+		// need to get next and prev audio tracks if I want to enable continuous playing
+		this.state = {
+			playing: false,
+			loadingNextChapter: false,
+			speedControlState: false,
+			volumeSliderState: false,
+			elipsisState: false,
+			duration: 0,
+			currentTime: 0,
+			nextTrack: {
+				index: 0,
+				path: props.audioPaths[0],
+				last: props.audioPaths.length === 0,
+			},
+			clickedPlay: false,
+			wasPlaying: false,
+		};
+	}
 
-  componentDidMount() {
-    if (this.props.audioPaths.length) {
-      this.props.audioPaths.forEach((path) => this.preLoadPath(path));
-    }
-    // If auto play is enabled I need to start the player
-    if (this.props.autoPlay) {
-      // Checking User Agent because the canplay event fails silently on mobile apple devices
-      if (
-        navigator &&
-        navigator.userAgent &&
-        /iPhone|iPod|iPad/i.test(navigator.userAgent)
-      ) {
-        this.audioRef.addEventListener('loadedmetadata', this.autoPlayListener);
-      } else {
-        this.audioRef.addEventListener('canplay', this.autoPlayListener);
-      }
-    }
-    this.audioRef.playbackRate = this.props.playbackRate;
-    // Add all the event listeners I need for the audio player
-    this.audioRef.addEventListener(
-      'durationchange',
-      this.durationChangeEventListener,
-    );
-    this.audioRef.addEventListener('timeupdate', this.timeUpdateEventListener);
-    this.audioRef.addEventListener('seeking', this.seekingEventListener);
-    this.audioRef.addEventListener('seeked', this.seekedEventListener);
-    this.audioRef.addEventListener('ended', this.endedEventListener);
-    this.audioRef.addEventListener('playing', this.playingEventListener);
+	componentDidMount() {
+		if (this.props.audioPaths.length) {
+			this.props.audioPaths.forEach((path) => this.preLoadPath(path));
+		}
+		// If auto play is enabled I need to start the player
+		if (this.props.autoPlay) {
+			// Checking User Agent because the canplay event fails silently on mobile apple devices
+			if (
+				navigator?.userAgent &&
+				/iPhone|iPod|iPad/i.test(navigator.userAgent)
+			) {
+				this.audioRef.addEventListener('loadedmetadata', this.autoPlayListener);
+			} else {
+				this.audioRef.addEventListener('canplay', this.autoPlayListener);
+			}
+		}
+		this.audioRef.playbackRate = this.props.playbackRate;
+		// Add all the event listeners I need for the audio player
+		this.audioRef.addEventListener(
+			'durationchange',
+			this.durationChangeEventListener,
+		);
+		this.audioRef.addEventListener('timeupdate', this.timeUpdateEventListener);
+		this.audioRef.addEventListener('seeking', this.seekingEventListener);
+		this.audioRef.addEventListener('seeked', this.seekedEventListener);
+		this.audioRef.addEventListener('ended', this.endedEventListener);
+		this.audioRef.addEventListener('playing', this.playingEventListener);
 
-    Router.router.events.on('routeChangeStart', this.handleRouteChange);
-    if (this.props.audioSource) {
-      this.audioRef.load();
-    }
+		Router.router.events.on('routeChangeStart', this.handleRouteChange);
+		if (this.props.audioSource) {
+			this.audioRef.load();
+		}
 
-    if (!this.props.hasAudio && this.props.audioPlayerState) {
-      this.setAudioPlayerState(false);
-    }
+		if (!this.props.hasAudio && this.props.audioPlayerState) {
+			this.setAudioPlayerState(false);
+		}
 
-    this.getAudio(
-      this.props.activeFilesets,
-      this.props.activeBookId,
-      this.props.activeChapter,
-      this.props.audioType,
-    );
-  }
+		this.getAudio(
+			this.props.activeFilesets,
+			this.props.activeBookId,
+			this.props.activeChapter,
+			this.props.audioType,
+		);
+	}
 
-  componentDidUpdate(nextProps) {
-    if (this.props.hasVideo && this.props.videoPlayerOpen) {
-      // this.pauseAudio();
-    }
-    if (
-      nextProps.activeTextId !== this.props.activeTextId ||
-      nextProps.activeBookId !== this.props.activeBookId ||
-      nextProps.activeChapter !== this.props.activeChapter ||
-      nextProps.audioType !== this.props.audioType ||
-      nextProps.verseNumber !== this.props.verseNumber
-    ) {
-      this.getAudio(
-        this.props.activeFilesets,
-        this.props.activeBookId,
-        this.props.activeChapter,
-        this.props.audioType,
-      );
-    }
-    if (nextProps.audioSource !== this.props.audioSource) {
-      if (this.props.audioSource && !nextProps.audioSource) {
-        this.setAudioPlayerState(true);
-      }
-      if (this.props.audioSource) {
-        this.setState({ playing: false, loadingNextChapter: false });
-      } else if (
-        nextProps.audioPlayerState &&
-        (!this.props.audioSource || !this.props.hasAudio)
-      ) {
-        this.setState({ playing: false }, () =>
-          this.setAudioPlayerState(false),
-        );
-      }
-    }
+	componentDidUpdate(prevProps) {
+		if (this.props.hasVideo && this.props.videoPlayerOpen) {
+			// this.pauseAudio();
+		}
+		if (
+			prevProps.activeTextId !== this.props.activeTextId ||
+			prevProps.activeBookId !== this.props.activeBookId ||
+			prevProps.activeChapter !== this.props.activeChapter ||
+			prevProps.audioType !== this.props.audioType ||
+			prevProps.verseNumber !== this.props.verseNumber ||
+			!isEqual(prevProps.activeFilesets, this.props.activeFilesets)
+		) {
+			this.getAudio(
+				this.props.activeFilesets,
+				this.props.activeBookId,
+				this.props.activeChapter,
+				this.props.audioType,
+			);
 
-    if (this.props.autoPlay) {
-      if (
-        navigator &&
-        navigator.userAgent &&
-        /iPhone|iPod|iPad/i.test(navigator.userAgent)
-      ) {
-        this.audioRef.addEventListener('loadedmetadata', this.autoPlayListener);
-      } else {
-        this.audioRef.addEventListener('canplay', this.autoPlayListener);
-      }
-    } else if (!this.props.autoPlay) {
-      if (
-        navigator &&
-        navigator.userAgent &&
-        /iPhone|iPod|iPad/i.test(navigator.userAgent)
-      ) {
-        this.audioRef.removeEventListener(
-          'loadedmetadata',
-          this.autoPlayListener,
-        );
-      } else {
-        this.audioRef.removeEventListener('canplay', this.autoPlayListener);
-      }
-    }
+			this.setTextLoadingState({ state: false });
+		}
+		if (prevProps.audioSource !== this.props.audioSource) {
+			if (this.props.audioSource && !prevProps.audioSource) {
+				this.setAudioPlayerState(true);
+			}
+			if (this.props.audioSource) {
+				this.setState({ playing: false, loadingNextChapter: false });
+			} else if (
+				prevProps.audioPlayerState &&
+				(!this.props.audioSource || !this.props.hasAudio)
+			) {
+				this.setState({ playing: false }, () =>
+					this.setAudioPlayerState(false),
+				);
+			}
+		}
 
-    if (
-      !isEqual(nextProps.audioPaths, this.props.audioPaths) &&
-      this.props.audioPaths.length
-    ) {
-      this.props.audioPaths.forEach((path) => this.preLoadPath(path));
-      this.setState({
-        nextTrack: {
-          index: 0,
-          path: this.props.audioPaths[0],
-          last: this.props.audioPaths.length === 0,
-        },
-      });
-    }
+		if (this.props.autoPlay) {
+			if (
+				navigator?.userAgent &&
+				/iPhone|iPod|iPad/i.test(navigator.userAgent)
+			) {
+				this.audioRef.addEventListener('loadedmetadata', this.autoPlayListener);
+			} else {
+				this.audioRef.addEventListener('canplay', this.autoPlayListener);
+			}
+		} else if (!this.props.autoPlay) {
+			if (
+				navigator?.userAgent &&
+				/iPhone|iPod|iPad/i.test(navigator.userAgent)
+			) {
+				this.audioRef.removeEventListener(
+					'loadedmetadata',
+					this.autoPlayListener,
+				);
+			} else {
+				this.audioRef.removeEventListener('canplay', this.autoPlayListener);
+			}
+		}
 
-    // Ensure that the player volume and state volume stay in sync
-    if (this.audioRef) {
-      if (this.audioRef.volume !== nextProps.volume) {
-        this.audioRef.volume = nextProps.volume;
-      }
-      // Ensure that the player playback rate and state playback rate stay in sync
-      if (this.audioRef.playbackRate !== nextProps.playbackRate) {
-        this.audioRef.playbackRate = nextProps.playbackRate;
-      }
-      if (
-        this.state.wasPlaying &&
-        this.props.audioSource !== nextProps.audioSource
-      ) {
-        this.playAudio(nextProps.audioSource);
-      }
-    }
-  }
+		if (
+			!isEqual(prevProps.audioPaths, this.props.audioPaths) &&
+			this.props.audioPaths.length
+		) {
+			this.props.audioPaths.forEach((path) => this.preLoadPath(path));
+			this.setState({
+				nextTrack: {
+					index: 0,
+					path: this.props.audioPaths[0],
+					last: this.props.audioPaths.length === 0,
+				},
+			});
+		}
 
-  componentWillUnmount() {
-    // Removing all the event listeners in the case that this component is unmounted
-    if (
-      navigator &&
-      navigator.userAgent &&
-      /iPhone|iPod|iPad/i.test(navigator.userAgent)
-    ) {
-      this.audioRef.removeEventListener(
-        'loadedmetadata',
-        this.autoPlayListener,
-      );
-    } else {
-      this.audioRef.removeEventListener('canplay', this.autoPlayListener);
-    }
-    this.audioRef.removeEventListener(
-      'durationchange',
-      this.durationChangeEventListener,
-    );
-    this.audioRef.removeEventListener(
-      'timeupdate',
-      this.timeUpdateEventListener,
-    );
-    this.audioRef.removeEventListener('seeking', this.seekingEventListener);
-    this.audioRef.removeEventListener('seeked', this.seekedEventListener);
-    this.audioRef.removeEventListener('ended', this.endedEventListener);
-    this.audioRef.removeEventListener('playing', this.playingEventListener);
+		// Ensure that the player volume and state volume stay in sync
+		if (this.audioRef) {
+			if (this.audioRef.volume !== prevProps.volume) {
+				this.audioRef.volume = prevProps.volume;
+			}
+			// Ensure that the player playback rate and state playback rate stay in sync
+			if (this.audioRef.playbackRate !== prevProps.playbackRate) {
+				this.audioRef.playbackRate = prevProps.playbackRate;
+			}
+			if (
+				this.state.wasPlaying &&
+				this.props.audioSource !== prevProps.audioSource
+			) {
+				this.playAudio(prevProps.audioSource);
+			}
+		}
+	}
 
-    Router.router.events.off('routeChangeStart', this.handleRouteChange);
-  }
+	componentWillUnmount() {
+		// Removing all the event listeners in the case that this component is unmounted
+		if (navigator?.userAgent && /iPhone|iPod|iPad/i.test(navigator.userAgent)) {
+			this.audioRef.removeEventListener(
+				'loadedmetadata',
+				this.autoPlayListener,
+			);
+		} else {
+			this.audioRef.removeEventListener('canplay', this.autoPlayListener);
+		}
+		this.audioRef.removeEventListener(
+			'durationchange',
+			this.durationChangeEventListener,
+		);
+		this.audioRef.removeEventListener(
+			'timeupdate',
+			this.timeUpdateEventListener,
+		);
+		this.audioRef.removeEventListener('seeking', this.seekingEventListener);
+		this.audioRef.removeEventListener('seeked', this.seekedEventListener);
+		this.audioRef.removeEventListener('ended', this.endedEventListener);
+		this.audioRef.removeEventListener('playing', this.playingEventListener);
 
-  setCurrentTime = (time) => {
-    this.setState(
-      {
-        currentTime: time,
-      },
-      () => {
-        this.audioRef.currentTime = time;
-      },
-    );
-  };
+		Router.router.events.off('routeChangeStart', this.handleRouteChange);
+	}
 
-  setAudioPlayerRef = (el) => {
-    // eslint-disable-next-line react/no-unused-class-component-methods
-    this.audioPlayerContainer = el;
-  };
+	setCurrentTime = (time) => {
+		this.setState(
+			{
+				currentTime: time,
+			},
+			() => {
+				this.audioRef.currentTime = time;
+			},
+		);
+	};
 
-  setSpeedControlState = (state) =>
-    this.setState({
-      speedControlState: state,
-    });
+	setAudioPlayerRef = (el) => {
+		// eslint-disable-next-line react/no-unused-class-component-methods
+		this.audioPlayerContainer = el;
+	};
 
-  setVolumeSliderState = (state) =>
-    this.setState({
-      volumeSliderState: state,
-    });
+	setSpeedControlState = (state) =>
+		this.setState({
+			speedControlState: state,
+		});
 
-  setElipsisState = (state) =>
-    this.setState({
-      elipsisState: state,
-    });
+	setVolumeSliderState = (state) =>
+		this.setState({
+			volumeSliderState: state,
+		});
 
-  setAudioPlayerState = (state) =>
-    this.props.dispatch(setAudioPlayerState(state));
+	setElipsisState = (state) =>
+		this.setState({
+			elipsisState: state,
+		});
 
-  getAudio = async (filesets, bookId, chapter, audioType) => {
-    const audio = await getAudioAsyncCall(filesets, bookId, chapter, audioType);
-    this.props.dispatch({ type: 'loadaudio', ...audio });
-  };
+	setAudioPlayerState = (state) =>
+		this.props.dispatch(setAudioPlayerState(state));
 
-  getVolumeSvg(volume) {
-    if (volume <= 0.25) {
-      return <SvgWrapper className={'icon'} fill="#fff" svgid="volume_low" />;
-    } else if (volume <= 0.5) {
-      return <SvgWrapper className={'icon'} fill="#fff" svgid="volume_1" />;
-    } else if (volume <= 0.75) {
-      return <SvgWrapper className={'icon'} fill="#fff" svgid="volume_2" />;
-    }
-    return <SvgWrapper className={'icon'} fill="#fff" svgid="volume_max" />;
-  }
+	setTextLoadingState = (props) =>
+		this.props.dispatch(setChapterTextLoadingState(props));
 
-  handleRef = (el) => {
-    this.audioRef = el;
-  };
+	getAudio = async (filesets, bookId, chapter, audioType) => {
+		const audio = await getAudioAsyncCall(filesets, bookId, chapter, audioType);
+		this.props.dispatch({ type: 'loadaudio', ...audio });
+	};
 
-  handleRouteChange = () => {
-    this.setCurrentTime(0);
-    this.pauseAudio();
-    this.setState({ loadingNextChapter: true });
-  };
+	getVolumeSvg(volume) {
+		if (volume <= 0.25) {
+			return <SvgWrapper className={'icon'} fill="#fff" svgid="volume_low" />;
+		} else if (volume <= 0.5) {
+			return <SvgWrapper className={'icon'} fill="#fff" svgid="volume_1" />;
+		} else if (volume <= 0.75) {
+			return <SvgWrapper className={'icon'} fill="#fff" svgid="volume_2" />;
+		}
+		return <SvgWrapper className={'icon'} fill="#fff" svgid="volume_max" />;
+	}
 
-  handleBackgroundClick = () => {
-    if (!this.props.audioPlayerState) {
-      this.toggleAudioPlayer();
-    }
-  };
+	handleRef = (el) => {
+		this.audioRef = el;
+	};
 
-  updateVolume = (volume) => {
-    if (volume !== this.props.volume) {
-      document.cookie = `bible_is_volume=${volume};path=/`;
-      this.audioRef.volume = volume;
-      this.props.dispatch(setVolume({ value: volume }));
-    }
-  };
+	handleRouteChange = () => {
+		this.setCurrentTime(0);
+		this.pauseAudio();
+		this.setState({ loadingNextChapter: true });
+	};
 
-  autoPlayListener = () => {
-    const { loadingNextChapter, clickedPlay } = this.state;
-    const { audioPlayerState, changingVersion } = this.props;
+	handleBackgroundClick = () => {
+		if (!this.props.audioPlayerState) {
+			this.toggleAudioPlayer();
+		}
+	};
 
-    // can accept event as a parameter
-    if (this.audioRef && this.audioRef.duration) {
-      this.setState({
-        duration: this.audioRef.duration,
-      });
-    }
-    // If the chapter is loaded and the player is open
-    if (
-      !loadingNextChapter &&
-      !changingVersion &&
-      audioPlayerState &&
-      clickedPlay
-    ) {
-      this.playAudio();
-    }
-  };
+	updateVolume = (volume) => {
+		if (volume !== this.props.volume) {
+			document.cookie = `bible_is_volume=${volume};path=/`;
+			this.audioRef.volume = volume;
+			this.props.dispatch(setVolume({ value: volume }));
+		}
+	};
 
-  durationChangeEventListener = (e) => {
-    this.setState({
-      duration: e.target.duration,
-    });
-  };
+	autoPlayListener = () => {
+		const { loadingNextChapter, clickedPlay } = this.state;
+		const { audioPlayerState, changingVersion } = this.props;
 
-  timeUpdateEventListener = (e) => {
-    this.setState({
-      currentTime: e.target.currentTime,
-    });
-  };
+		// can accept event as a parameter
+		if (this.audioRef?.duration) {
+			this.setState({
+				duration: this.audioRef.duration,
+			});
+		}
+		// If the chapter is loaded and the player is open
+		if (
+			!loadingNextChapter &&
+			!changingVersion &&
+			audioPlayerState &&
+			clickedPlay
+		) {
+			this.playAudio();
+		}
+	};
 
-  seekingEventListener = (e) => {
-    this.setState({
-      currentTime: e.target.currentTime,
-    });
-  };
+	durationChangeEventListener = (e) => {
+		this.setState({
+			duration: e.target.duration,
+		});
+	};
 
-  seekedEventListener = (e) => {
-    this.setState({
-      currentTime: e.target.currentTime,
-    });
-  };
+	timeUpdateEventListener = (e) => {
+		this.setState({
+			currentTime: e.target.currentTime,
+		});
+	};
 
-  endedEventListener = () => {
-    if (!this.state.nextTrack.last && this.props.audioPaths.length) {
-      this.audioRef.src = this.state.nextTrack.path;
-      this.setState(
-        (prevState) => ({
-          nextTrack: {
-            path: this.props.audioPaths[prevState.nextTrack.index + 1],
-            index: prevState.nextTrack.index + 1,
-            last:
-              this.props.audioPaths.length === prevState.nextTrack.index + 1,
-          },
-          // May need to trigger a play event after the next track loaded in
-        }),
-        () => this.playAudio(),
-      );
-    } else {
-      if (this.props.autoPlay) {
-        this.skipForward();
-      }
-      this.pauseAudio();
-    }
-  };
+	seekingEventListener = (e) => {
+		this.setState({
+			currentTime: e.target.currentTime,
+		});
+	};
 
-  preLoadPath = (path) => {
-    const audio = new Audio();
-    audio.src = path;
-  };
+	seekedEventListener = (e) => {
+		this.setState({
+			currentTime: e.target.currentTime,
+		});
+	};
 
-  playingEventListener = (e) => {
-    if (this.state.playing && e.target.paused) {
-      this.setState({
-        playing: false,
-      });
-    } else if (!this.state.playing && !e.target.paused) {
-      this.setState({
-        playing: true,
-      });
-    }
-  };
+	endedEventListener = () => {
+		if (!this.state.nextTrack.last && this.props.audioPaths.length) {
+			this.audioRef.src = this.state.nextTrack.path;
+			this.setState(
+				(prevState) => ({
+					nextTrack: {
+						path: this.props.audioPaths[prevState.nextTrack.index + 1],
+						index: prevState.nextTrack.index + 1,
+						last:
+							this.props.audioPaths.length === prevState.nextTrack.index + 1,
+					},
+					// May need to trigger a play event after the next track loaded in
+				}),
+				() => this.playAudio(),
+			);
+		} else {
+			if (this.props.autoPlay) {
+				this.skipForward();
+			}
+			this.pauseAudio();
+		}
+	};
 
-  pauseAudio = () => {
-    this.audioRef.pause();
-    this.setState({
-      playing: false,
-    });
-  };
+	preLoadPath = (path) => {
+		const audio = new Audio();
+		audio.src = path;
+	};
 
-  playFile(video) {
-    const promise = video.play();
-    if (promise !== undefined) {
-      promise
-        .then(() => {
-          // Autoplay started
-        })
-        .catch(() => {
-          // Autoplay was prevented.
-          video.play();
-        });
-    }
-  }
+	playingEventListener = (e) => {
+		if (this.state.playing && e.target.paused) {
+			this.setState({
+				playing: false,
+			});
+		} else if (!this.state.playing && !e.target.paused) {
+			this.setState({
+				playing: true,
+			});
+		}
+	};
 
-  playAudioOnChrome(audioSource) {
-    if (!audioSource) {
-      return;
-    }
-    const hls = new Hls();
-    const video = this.audioRef;
-    // bind them together
-    hls.on(Hls.Events.MEDIA_ATTACHED, () => {
-      const parsedSource = addFilesetQueryParams(audioSource);
-      hls.loadSource(parsedSource);
-    });
-    hls.on(Hls.Events.MANIFEST_PARSED, () => {
-      this.playFile(video);
-    });
-    hls.attachMedia(video);
-  }
+	pauseAudio = () => {
+		this.audioRef.pause();
+		this.setState({
+			playing: false,
+		});
+	};
 
-  playAudioOnSafari = () => {
-    const { loadingNextChapter, currentTime } = this.state;
+	playFile(video) {
+		const promise = video.play();
+		if (promise !== undefined) {
+			promise
+				.then(() => {
+					// Autoplay started
+				})
+				.catch(() => {
+					// Autoplay was prevented.
+					video.play();
+				});
+		}
+	}
 
-    if (loadingNextChapter) {
-      return;
-    }
-    const playPromise = this.audioRef.play();
-    // All modern browsers return a promise
-    if (this.props.videoPlayerOpen && this.props.hasVideo) {
-      this.pauseAudio();
-      return;
-    }
-    // This is only because IE doesn't return a promise
-    if (playPromise) {
-      playPromise
-        .then(() => {
-          if (currentTime !== this.audioRef.currentTime) {
-            this.audioRef.currentTime = currentTime;
-          }
-          this.setState({
-            playing: true,
-            clickedPlay: true,
-          });
-        })
-        .catch((err) => {
-          if (process.env.NODE_ENV !== 'production') {
-            /* eslint-disable no-console */
-            console.error('Error with playing audio: ', err);
-            /* eslint-enable no-console */
-          }
-        });
-    } else {
-      // This is so IE will still show the svg for the pause button and such
-      if (currentTime !== this.audioRef.currentTime) {
-        this.audioRef.currentTime = currentTime;
-      }
-      this.setState({
-        playing: true,
-        clickedPlay: true,
-      });
-    }
-  };
+	playAudioOnChrome(audioSource) {
+		if (!audioSource) {
+			return;
+		}
+		const hls = new Hls();
+		const video = this.audioRef;
+		// bind them together
+		hls.on(Hls.Events.MEDIA_ATTACHED, () => {
+			const parsedSource = addFilesetQueryParams(audioSource);
+			hls.loadSource(parsedSource);
+		});
+		hls.on(Hls.Events.MANIFEST_PARSED, () => {
+			this.playFile(video);
+		});
+		hls.attachMedia(video);
+	}
 
-  playAudio(audioSource) {
-    if (!isFileSet(audioSource)) {
-      this.playAudioOnSafari();
-    } else {
-      this.playAudioOnChrome(audioSource);
-    }
-  }
+	playAudioOnSafari = () => {
+		const { loadingNextChapter, currentTime } = this.state;
 
-  updatePlayerSpeed = (rate) => {
-    if (this.props.playbackRate !== rate) {
-      document.cookie = `bible_is_playbackrate=${JSON.stringify(rate)};path=/`;
-      this.audioRef.playbackRate = rate;
-      // set playback
-      this.props.dispatch(setPlaybackRate({ value: rate }));
-    }
-  };
+		if (loadingNextChapter) {
+			return;
+		}
+		const playPromise = this.audioRef.play();
+		// All modern browsers return a promise
+		if (this.props.videoPlayerOpen && this.props.hasVideo) {
+			this.pauseAudio();
+			return;
+		}
+		// This is only because IE doesn't return a promise
+		if (playPromise) {
+			playPromise
+				.then(() => {
+					if (currentTime !== this.audioRef.currentTime) {
+						this.audioRef.currentTime = currentTime;
+					}
+					this.setState({
+						playing: true,
+						clickedPlay: true,
+					});
+				})
+				.catch((err) => {
+					if (process.env.NODE_ENV !== 'production') {
+						/* eslint-disable no-console */
+						console.error('Error with playing audio: ', err);
+						/* eslint-enable no-console */
+					}
+				});
+		} else {
+			// This is so IE will still show the svg for the pause button and such
+			if (currentTime !== this.audioRef.currentTime) {
+				this.audioRef.currentTime = currentTime;
+			}
+			this.setState({
+				playing: true,
+				clickedPlay: true,
+			});
+		}
+	};
 
-  skipForward = () => {
-    this.setCurrentTime(0);
-    this.setState(
-      (oldState) => ({
-        wasPlaying: oldState.playing,
-        playing: false,
-        loadingNextChapter: true,
-      }),
-      () => {
-        Router.push(
-          getNextChapterUrl({
-            books: this.props.books,
-            chapter: this.props.activeChapter,
-            bookId: this.props.activeBookId.toLowerCase(),
-            textId: this.props.activeTextId.toLowerCase(),
-            verseNumber: this.props.verseNumber,
-            text: this.props.textData.text,
-            audioType: this.props.audioType,
-            isHref: true,
-          }),
-          getNextChapterUrl({
-            books: this.props.books,
-            chapter: this.props.activeChapter,
-            bookId: this.props.activeBookId.toLowerCase(),
-            textId: this.props.activeTextId.toLowerCase(),
-            verseNumber: this.props.verseNumber,
-            text: this.props.textData.text,
-            audioType: this.props.audioType,
-            isHref: false,
-          }),
-        );
-      },
-    );
-    this.pauseAudio();
-  };
+	playAudio(audioSource) {
+		if (!isFileSet(audioSource)) {
+			this.playAudioOnSafari();
+		} else {
+			this.playAudioOnChrome(audioSource);
+		}
+	}
 
-  skipBack = () => {
-    this.setCurrentTime(0);
-    this.setState(
-      (oldState) => ({
-        wasPlaying: oldState.playing,
-        playing: false,
-        loadingNextChapter: true,
-      }),
-      () => {
-        Router.push(
-          getPreviousChapterUrl({
-            books: this.props.books,
-            chapter: this.props.activeChapter,
-            bookId: this.props.activeBookId.toLowerCase(),
-            textId: this.props.activeTextId.toLowerCase(),
-            verseNumber: this.props.verseNumber,
-            text: this.props.textData.text,
-            audioType: this.props.audioType,
-            isHref: true,
-          }),
-          getPreviousChapterUrl({
-            books: this.props.books,
-            chapter: this.props.activeChapter,
-            bookId: this.props.activeBookId.toLowerCase(),
-            textId: this.props.activeTextId.toLowerCase(),
-            verseNumber: this.props.verseNumber,
-            text: this.props.textData.text,
-            audioType: this.props.audioType,
-            isHref: false,
-          }),
-        );
-      },
-    );
-    this.pauseAudio();
-  };
+	updatePlayerSpeed = (rate) => {
+		if (this.props.playbackRate !== rate) {
+			document.cookie = `bible_is_playbackrate=${JSON.stringify(rate)};path=/`;
+			this.audioRef.playbackRate = rate;
+			// set playback
+			this.props.dispatch(setPlaybackRate({ value: rate }));
+		}
+	};
 
-  toggleAudioPlayer = () => {
-    if (this.props.audioSource && this.props.hasAudio) {
-      this.setAudioPlayerState(!this.props.audioPlayerState);
-    }
-  };
+	skipForward = () => {
+		this.setCurrentTime(0);
+		this.setState(
+			(oldState) => ({
+				wasPlaying: oldState.playing,
+				playing: false,
+				loadingNextChapter: true,
+			}),
+			() => {
+				Router.push(
+					getNextChapterUrl({
+						books: this.props.books,
+						chapter: this.props.activeChapter,
+						bookId: this.props.activeBookId.toLowerCase(),
+						textId: this.props.activeTextId.toLowerCase(),
+						verseNumber: this.props.verseNumber,
+						text: this.props.textData.text,
+						audioType: this.props.audioType,
+						isHref: true,
+					}),
+					getNextChapterUrl({
+						books: this.props.books,
+						chapter: this.props.activeChapter,
+						bookId: this.props.activeBookId.toLowerCase(),
+						textId: this.props.activeTextId.toLowerCase(),
+						verseNumber: this.props.verseNumber,
+						text: this.props.textData.text,
+						audioType: this.props.audioType,
+						isHref: false,
+					}),
+				);
+			},
+		);
+		this.pauseAudio();
+	};
 
-  handleAutoPlayChange = (e) => {
-    this.props.dispatch(toggleAutoPlay({ state: e.target.checked }));
-  };
+	skipBack = () => {
+		this.setCurrentTime(0);
+		this.setState(
+			(oldState) => ({
+				wasPlaying: oldState.playing,
+				playing: false,
+				loadingNextChapter: true,
+			}),
+			() => {
+				Router.push(
+					getPreviousChapterUrl({
+						books: this.props.books,
+						chapter: this.props.activeChapter,
+						bookId: this.props.activeBookId.toLowerCase(),
+						textId: this.props.activeTextId.toLowerCase(),
+						verseNumber: this.props.verseNumber,
+						text: this.props.textData.text,
+						audioType: this.props.audioType,
+						isHref: true,
+					}),
+					getPreviousChapterUrl({
+						books: this.props.books,
+						chapter: this.props.activeChapter,
+						bookId: this.props.activeBookId.toLowerCase(),
+						textId: this.props.activeTextId.toLowerCase(),
+						verseNumber: this.props.verseNumber,
+						text: this.props.textData.text,
+						audioType: this.props.audioType,
+						isHref: false,
+					}),
+				);
+			},
+		);
+		this.pauseAudio();
+	};
 
-  // Simpler to close all modals than to try and figure out which one to close
-  closeModals = ({ speed, volume }) => {
-    if (speed === 'speed') {
-      this.setState({
-        speedControlState: false,
-      });
-    } else if (volume === 'volume') {
-      this.setState({
-        volumeSliderState: false,
-      });
-    } else {
-      this.setState({
-        volumeSliderState: false,
-        speedControlState: false,
-        elipsisState: false,
-      });
-    }
-  };
+	toggleAudioPlayer = () => {
+		if (this.props.audioSource && this.props.hasAudio) {
+			this.setAudioPlayerState(!this.props.audioPlayerState);
+		}
+	};
 
-  pauseIcon = (
-    <div
-      id={'pause-audio'}
-      onClick={() => {
-        this.setState({ wasPlaying: false });
-        this.pauseAudio();
-      }}
-      className={'icon-wrap'}
-      title={messages.pauseTitle.defaultMessage}
-    >
-      <SvgWrapper className="svgitem icon" fill="#fff" svgid="pause" />
-      <FormattedMessage {...messages.pause} />
-    </div>
-  );
+	handleAutoPlayChange = (e) => {
+		this.props.dispatch(toggleAutoPlay({ state: e.target.checked }));
+	};
 
-  playIcon = () => (
-    <div
-      id={'play-audio'}
-      onClick={() => {
-        this.playAudio(this.props.audioSource);
-      }}
-      className={`icon-wrap ${(this.state.loadingNextChapter ||
-        this.props.changingVersion) &&
-        'audio-player-play-disabled'}`}
-      title={messages.playTitle.defaultMessage}
-    >
-      <SvgWrapper className="svgitem icon" svgid="play" />
-      <FormattedMessage {...messages.play} />
-    </div>
-  );
+	// Simpler to close all modals than to try and figure out which one to close
+	closeModals = ({ speed, volume }) => {
+		if (speed === 'speed') {
+			this.setState({
+				speedControlState: false,
+			});
+		} else if (volume === 'volume') {
+			this.setState({
+				volumeSliderState: false,
+			});
+		} else {
+			this.setState({
+				volumeSliderState: false,
+				speedControlState: false,
+				elipsisState: false,
+			});
+		}
+	};
 
-  render() {
-    const {
-      audioSource: source,
-      hasAudio,
-      audioPlayerState,
-      videoPlayerOpen,
-      hasVideo,
-      audioType,
-      autoPlay,
-      volume,
-      playbackRate,
-      activeTextId,
-    } = this.props;
+	pauseIcon = (
+		<div
+			id={'pause-audio'}
+			onClick={() => {
+				this.setState({ wasPlaying: false });
+				this.pauseAudio();
+			}}
+			className={'icon-wrap'}
+			title={messages.pauseTitle.defaultMessage}
+		>
+			<SvgWrapper className="svgitem icon" fill="#fff" svgid="pause" />
+			<FormattedMessage {...messages.pause} />
+		</div>
+	);
 
-    return (
-      <>
-        <div
-          className={getClassNamesForAudioHandle({
-            audioSource: source,
-            hasAudio,
-            hasVideo,
-            audioPlayerState,
-            videoPlayerOpen,
-          })}
-          onClick={(e) => {
-            e.stopPropagation();
-            this.toggleAudioPlayer();
-          }}
-        >
-          <SvgWrapper
-            width="26px"
-            height="26px"
-            className={
-              (!videoPlayerOpen || !hasVideo) && audioPlayerState
-                ? 'audio-gripper'
-                : 'audio-gripper closed'
-            }
-            style={{ cursor: source ? 'pointer' : 'inherit' }}
-            svgid="arrow_down"
-          />
-        </div>
-        <div
-          className={getClassNamesForAudioBackground({
-            audioSource: source,
-            hasAudio,
-            hasVideo,
-            audioPlayerState,
-            videoPlayerOpen,
-          })}
-          ref={this.setAudioPlayerRef}
-          onClick={this.handleBackgroundClick}
-        >
-          <div
-            className={
-              audioPlayerState &&
-              (!videoPlayerOpen || !hasVideo) &&
-              hasAudio &&
-              source !== ''
-                ? 'audio-player-container'
-                : 'audio-player-container closed'
-            }
-          >
-            <NewChapterArrow
-              clickHandler={this.skipBack}
-              getNewUrl={getPreviousChapterUrl}
-              urlProps={{
-                books: this.props.books,
-                chapter: this.props.activeChapter,
-                bookId: this.props.activeBookId.toLowerCase(),
-                textId: activeTextId.toLowerCase(),
-                verseNumber: this.props.verseNumber,
-                text: this.props.textData.text,
-                audioType,
-              }}
-              disabled={false}
-              svgid={'previous'}
-              svgClasses={'svgitem icon'}
-              containerClasses={'icon-wrap'}
-              id={'previous-chapter-audio'}
-              title={messages.prevTitle.defaultMessage}
-              textProps={messages.prev}
-            />
-            {this.state.playing ? this.pauseIcon : this.playIcon()}
-            <NewChapterArrow
-              clickHandler={this.skipForward}
-              getNewUrl={getNextChapterUrl}
-              urlProps={{
-                books: this.props.books,
-                chapter: this.props.activeChapter,
-                bookId: this.props.activeBookId.toLowerCase(),
-                textId: activeTextId.toLowerCase(),
-                verseNumber: this.props.verseNumber,
-                text: this.props.textData.text,
-                audioType,
-              }}
-              disabled={false}
-              svgid={'next'}
-              svgClasses={'svgitem icon'}
-              containerClasses={'icon-wrap'}
-              id={'next-chapter-audio'}
-              title={messages.nextTitle.defaultMessage}
-              textProps={messages.next}
-            />
-            <AudioProgressBar
-              setCurrentTime={this.setCurrentTime}
-              duration={this.state.duration}
-              currentTime={this.state.currentTime}
-            />
-            <div
-              id={'autoplay-wrap'}
-              className={'icon-wrap'}
-              title={messages.autoplayTitle.defaultMessage}
-            >
-              <input
-                id={'autoplay'}
-                className={'custom-checkbox'}
-                type="checkbox"
-                onChange={this.handleAutoPlayChange}
-                defaultChecked={autoPlay}
-              />
-              <label htmlFor={'autoplay'}>
-                <FormattedMessage {...messages.autoplay} />
-              </label>
-            </div>
-            <div id="volume-wrap" className={'icon-wrap'}>
-              <div
-                title={messages.volumeTitle.defaultMessage}
-                className={
-                  this.state.volumeSliderState ? 'item active' : 'item'
-                }
-                id={'volume-button'}
-                onTouchEnd={(e) => {
-                  e.preventDefault();
-                  if (!this.state.volumeSliderState) {
-                    this.setVolumeSliderState(true);
-                  }
-                  this.setSpeedControlState(false);
-                  this.setElipsisState(false);
-                }}
-                onClick={() => {
-                  if (!this.state.volumeSliderState) {
-                    this.setVolumeSliderState(true);
-                  }
-                  this.setSpeedControlState(false);
-                  this.setElipsisState(false);
-                }}
-              >
-                {this.getVolumeSvg(volume)}
-                <FormattedMessage {...messages.volume} />
-              </div>
-              <VolumeSlider
-                active={this.state.volumeSliderState}
-                onCloseFunction={this.closeModals}
-                updateVolume={this.updateVolume}
-                volume={volume}
-              />
-            </div>
-            <div id="speed-wrap" className={'icon-wrap'}>
-              <div
-                title={messages.speedTitle.defaultMessage}
-                id={'speed-button'}
-                className={
-                  this.state.speedControlState ? 'item active' : 'item'
-                }
-                onTouchEnd={(e) => {
-                  e.preventDefault();
-                  if (!this.state.speedControlState) {
-                    this.setSpeedControlState(true);
-                  }
-                  this.setElipsisState(false);
-                  this.setVolumeSliderState(false);
-                }}
-                onClick={() => {
-                  if (!this.state.speedControlState) {
-                    this.setSpeedControlState(true);
-                  }
-                  this.setElipsisState(false);
-                  this.setVolumeSliderState(false);
-                }}
-              >
-                <PlaybackRateSvg playbackRate={playbackRate} />
-                <FormattedMessage {...messages.speed} />
-              </div>
-              <SpeedControl
-                active={this.state.speedControlState}
-                options={[0.75, 1, 1.25, 1.5, 2]}
-                onCloseFunction={this.closeModals}
-                setSpeed={this.updatePlayerSpeed}
-                playbackRate={playbackRate}
-              />
-            </div>
-          </div>
-          <video
-            ref={this.handleRef}
-            className="audio-player"
-            src={`${addFilesetQueryParams(source)}` || '_'}
-            data-src={`source-${addFilesetQueryParams(source)}-${source}`}
-          />
-        </div>
-      </>
-    );
-  }
+	playIcon = () => (
+		<div
+			id={'play-audio'}
+			onClick={() => {
+				this.playAudio(this.props.audioSource);
+			}}
+			className={`icon-wrap ${
+				(this.state.loadingNextChapter || this.props.changingVersion) &&
+				'audio-player-play-disabled'
+			}`}
+			title={messages.playTitle.defaultMessage}
+		>
+			<SvgWrapper className="svgitem icon" svgid="play" />
+			<FormattedMessage {...messages.play} />
+		</div>
+	);
+
+	render() {
+		const {
+			audioSource: source,
+			hasAudio,
+			audioPlayerState,
+			videoPlayerOpen,
+			hasVideo,
+			audioType,
+			autoPlay,
+			volume,
+			playbackRate,
+			activeTextId,
+		} = this.props;
+
+		return (
+			<>
+				<div
+					className={getClassNamesForAudioHandle({
+						audioSource: source,
+						hasAudio,
+						hasVideo,
+						audioPlayerState,
+						videoPlayerOpen,
+					})}
+					onClick={(e) => {
+						e.stopPropagation();
+						this.toggleAudioPlayer();
+					}}
+				>
+					<SvgWrapper
+						width="26px"
+						height="26px"
+						className={
+							(!videoPlayerOpen || !hasVideo) && audioPlayerState
+								? 'audio-gripper'
+								: 'audio-gripper closed'
+						}
+						style={{ cursor: source ? 'pointer' : 'inherit' }}
+						svgid="arrow_down"
+					/>
+				</div>
+				<div
+					className={getClassNamesForAudioBackground({
+						audioSource: source,
+						hasAudio,
+						hasVideo,
+						audioPlayerState,
+						videoPlayerOpen,
+					})}
+					ref={this.setAudioPlayerRef}
+					onClick={this.handleBackgroundClick}
+				>
+					<div
+						className={
+							audioPlayerState &&
+							(!videoPlayerOpen || !hasVideo) &&
+							hasAudio &&
+							source !== ''
+								? 'audio-player-container'
+								: 'audio-player-container closed'
+						}
+					>
+						<NewChapterArrow
+							clickHandler={this.skipBack}
+							getNewUrl={getPreviousChapterUrl}
+							urlProps={{
+								books: this.props.books,
+								chapter: this.props.activeChapter,
+								bookId: this.props.activeBookId.toLowerCase(),
+								textId: activeTextId.toLowerCase(),
+								verseNumber: this.props.verseNumber,
+								text: this.props.textData.text,
+								audioType,
+							}}
+							disabled={false}
+							svgid={'previous'}
+							svgClasses={'svgitem icon'}
+							containerClasses={'icon-wrap'}
+							id={'previous-chapter-audio'}
+							title={messages.prevTitle.defaultMessage}
+							textProps={messages.prev}
+						/>
+						{this.state.playing ? this.pauseIcon : this.playIcon()}
+						<NewChapterArrow
+							clickHandler={this.skipForward}
+							getNewUrl={getNextChapterUrl}
+							urlProps={{
+								books: this.props.books,
+								chapter: this.props.activeChapter,
+								bookId: this.props.activeBookId.toLowerCase(),
+								textId: activeTextId.toLowerCase(),
+								verseNumber: this.props.verseNumber,
+								text: this.props.textData.text,
+								audioType,
+							}}
+							disabled={false}
+							svgid={'next'}
+							svgClasses={'svgitem icon'}
+							containerClasses={'icon-wrap'}
+							id={'next-chapter-audio'}
+							title={messages.nextTitle.defaultMessage}
+							textProps={messages.next}
+						/>
+						<AudioProgressBar
+							setCurrentTime={this.setCurrentTime}
+							duration={this.state.duration}
+							currentTime={this.state.currentTime}
+						/>
+						<div
+							id={'autoplay-wrap'}
+							className={'icon-wrap'}
+							title={messages.autoplayTitle.defaultMessage}
+						>
+							<input
+								id={'autoplay'}
+								className={'custom-checkbox'}
+								type="checkbox"
+								onChange={this.handleAutoPlayChange}
+								defaultChecked={autoPlay}
+							/>
+							<label htmlFor={'autoplay'}>
+								<FormattedMessage {...messages.autoplay} />
+							</label>
+						</div>
+						<div id="volume-wrap" className={'icon-wrap'}>
+							<div
+								title={messages.volumeTitle.defaultMessage}
+								className={
+									this.state.volumeSliderState ? 'item active' : 'item'
+								}
+								id={'volume-button'}
+								onTouchEnd={(e) => {
+									e.preventDefault();
+									if (!this.state.volumeSliderState) {
+										this.setVolumeSliderState(true);
+									}
+									this.setSpeedControlState(false);
+									this.setElipsisState(false);
+								}}
+								onClick={() => {
+									if (!this.state.volumeSliderState) {
+										this.setVolumeSliderState(true);
+									}
+									this.setSpeedControlState(false);
+									this.setElipsisState(false);
+								}}
+							>
+								{this.getVolumeSvg(volume)}
+								<FormattedMessage {...messages.volume} />
+							</div>
+							<VolumeSlider
+								active={this.state.volumeSliderState}
+								onCloseFunction={this.closeModals}
+								updateVolume={this.updateVolume}
+								volume={volume}
+							/>
+						</div>
+						<div id="speed-wrap" className={'icon-wrap'}>
+							<div
+								title={messages.speedTitle.defaultMessage}
+								id={'speed-button'}
+								className={
+									this.state.speedControlState ? 'item active' : 'item'
+								}
+								onTouchEnd={(e) => {
+									e.preventDefault();
+									if (!this.state.speedControlState) {
+										this.setSpeedControlState(true);
+									}
+									this.setElipsisState(false);
+									this.setVolumeSliderState(false);
+								}}
+								onClick={() => {
+									if (!this.state.speedControlState) {
+										this.setSpeedControlState(true);
+									}
+									this.setElipsisState(false);
+									this.setVolumeSliderState(false);
+								}}
+							>
+								<PlaybackRateSvg playbackRate={playbackRate} />
+								<FormattedMessage {...messages.speed} />
+							</div>
+							<SpeedControl
+								active={this.state.speedControlState}
+								options={[0.75, 1, 1.25, 1.5, 2]}
+								onCloseFunction={this.closeModals}
+								setSpeed={this.updatePlayerSpeed}
+								playbackRate={playbackRate}
+							/>
+						</div>
+					</div>
+					<video
+						ref={this.handleRef}
+						className="audio-player"
+						src={`${addFilesetQueryParams(source)}` || '_'}
+						data-src={`source-${addFilesetQueryParams(source)}-${source}`}
+					/>
+				</div>
+			</>
+		);
+	}
 }
 
 AudioPlayer.propTypes = {
-  textData: PropTypes.object,
-  audioSource: PropTypes.string,
-  audioType: PropTypes.string,
-  activeBookId: PropTypes.string,
-  activeTextId: PropTypes.string.isRequired,
-  verseNumber: PropTypes.string,
-  dispatch: PropTypes.func,
-  hasAudio: PropTypes.bool,
-  hasVideo: PropTypes.bool,
-  autoPlay: PropTypes.bool,
-  videoPlayerOpen: PropTypes.bool,
-  isScrollingDown: PropTypes.bool,
-  changingVersion: PropTypes.bool,
-  audioPlayerState: PropTypes.bool.isRequired,
-  audioPaths: PropTypes.array,
-  activeFilesets: PropTypes.array,
-  books: PropTypes.array,
-  activeChapter: PropTypes.number,
-  playbackRate: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
-  volume: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+	textData: PropTypes.object,
+	audioSource: PropTypes.string,
+	audioType: PropTypes.string,
+	activeBookId: PropTypes.string,
+	activeTextId: PropTypes.string.isRequired,
+	verseNumber: PropTypes.string,
+	dispatch: PropTypes.func,
+	hasAudio: PropTypes.bool,
+	hasVideo: PropTypes.bool,
+	autoPlay: PropTypes.bool,
+	videoPlayerOpen: PropTypes.bool,
+	isScrollingDown: PropTypes.bool,
+	changingVersion: PropTypes.bool,
+	audioPlayerState: PropTypes.bool.isRequired,
+	audioPaths: PropTypes.array,
+	activeFilesets: PropTypes.array,
+	books: PropTypes.array,
+	activeChapter: PropTypes.number,
+	playbackRate: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+	volume: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
 };
 
 const mapStateToProps = createStructuredSelector({
-  // Audio Domain
-  audioplayer: makeSelectAudioPlayer(),
-  // Settings Domain
-  autoPlay: selectAutoPlay(),
-  playbackRate: selectPlaybackRate(),
-  volume: selectVolume(),
-  // Homepage Domain
-  books: selectorGenerator('books', 'homepage'),
-  hasAudio: selectorGenerator('hasAudio', 'homepage'),
-  hasVideo: selectorGenerator('hasVideo', 'homepage'),
-  audioSource: selectorGenerator('audioSource', 'homepage'),
-  audioPaths: selectorGenerator('audioPaths', 'homepage'),
-  activeFilesets: selectorGenerator('activeFilesets', 'homepage'),
-  videoPlayerOpen: selectorGenerator('videoPlayerOpen', 'homepage'),
-  audioPlayerState: selectorGenerator('audioPlayerState', 'homepage'),
-  activeBookId: selectorGenerator('activeBookId', 'homepage'),
-  activeTextId: selectorGenerator('activeTextId', 'homepage'),
-  activeChapter: selectorGenerator('activeChapter', 'homepage'),
-  changingVersion: selectorGenerator('changingVersion', 'homepage'),
-  // Other Selectors
-  textData: selectUserNotes(),
+	// Audio Domain
+	audioplayer: makeSelectAudioPlayer(),
+	// Settings Domain
+	autoPlay: selectAutoPlay(),
+	playbackRate: selectPlaybackRate(),
+	volume: selectVolume(),
+	// Homepage Domain
+	books: selectorGenerator('books', 'homepage'),
+	hasAudio: selectorGenerator('hasAudio', 'homepage'),
+	hasVideo: selectorGenerator('hasVideo', 'homepage'),
+	audioSource: selectorGenerator('audioSource', 'homepage'),
+	audioPaths: selectorGenerator('audioPaths', 'homepage'),
+	activeFilesets: selectorGenerator('activeFilesets', 'homepage'),
+	videoPlayerOpen: selectorGenerator('videoPlayerOpen', 'homepage'),
+	audioPlayerState: selectorGenerator('audioPlayerState', 'homepage'),
+	activeBookId: selectorGenerator('activeBookId', 'homepage'),
+	activeTextId: selectorGenerator('activeTextId', 'homepage'),
+	activeChapter: selectorGenerator('activeChapter', 'homepage'),
+	changingVersion: selectorGenerator('changingVersion', 'homepage'),
+	// Other Selectors
+	textData: selectUserNotes(),
 });
 
 function mapDispatchToProps(dispatch) {
-  return {
-    dispatch,
-  };
+	return {
+		dispatch,
+	};
 }
 
-const withConnect = connect(
-  mapStateToProps,
-  mapDispatchToProps,
-);
+const withConnect = connect(mapStateToProps, mapDispatchToProps);
 
 const withReducer = injectReducer({ key: 'audioPlayer', reducer });
 
-export default compose(
-  withReducer,
-  withConnect,
-)(AudioPlayer);
+export default compose(withReducer, withConnect)(AudioPlayer);

--- a/app/containers/HomePage/index.js
+++ b/app/containers/HomePage/index.js
@@ -31,642 +31,633 @@ import makeSelectProfile from '../Profile/selectors';
 import { getBookmarksForChapter } from '../Notes/actions';
 import { setHasVideo } from '../VideoPlayer/actions';
 import {
-  getNotes,
-  getHighlights,
-  getCopyrights,
-  toggleProfile,
-  toggleNotesModal,
-  toggleSearchModal,
-  toggleSettingsModal,
-  toggleChapterSelection,
-  toggleVersionSelection,
-  toggleFirstLoadForTextSelection,
-  setChapterTextLoadingState,
-  resetBookmarkState,
-  initApplication,
-  changeVersion,
+	getNotes,
+	getHighlights,
+	getCopyrights,
+	toggleProfile,
+	toggleNotesModal,
+	toggleSearchModal,
+	toggleSettingsModal,
+	toggleChapterSelection,
+	toggleVersionSelection,
+	toggleFirstLoadForTextSelection,
+	setChapterTextLoadingState,
+	resetBookmarkState,
+	initApplication,
+	changeVersion,
 } from './actions';
 import makeSelectHomePage, {
-  selectSettings,
-  selectFormattedSource,
-  selectAuthenticationStatus,
-  selectUserId,
-  selectMenuOpenState,
-  selectUserNotes,
-  selectActiveNotesView,
+	selectSettings,
+	selectFormattedSource,
+	selectAuthenticationStatus,
+	selectUserId,
+	selectMenuOpenState,
+	selectUserNotes,
+	selectActiveNotesView,
 } from './selectors';
 import reducer from './reducer';
 import saga from './saga';
 import {
-  applyTheme,
-  applyFontFamily,
-  applyFontSize,
-  toggleWordsOfJesus,
+	applyTheme,
+	applyFontFamily,
+	applyFontSize,
+	toggleWordsOfJesus,
 } from '../Settings/themes';
 import { setAudioType } from '../AudioPlayer/actions';
 
 const VideoPlayer = dynamic(import('../VideoPlayer'), {
-  loading: () => null,
+	loading: () => null,
 });
 const Profile = dynamic(import('../Profile'), {
-  loading: () => null,
+	loading: () => null,
 });
 const Settings = dynamic(import('../Settings'), {
-  loading: () => null,
+	loading: () => null,
 });
 const SearchContainer = dynamic(import('../SearchContainer'), {
-  loading: () => null,
+	loading: () => null,
 });
 const Notes = dynamic(import('../Notes'), {
-  loading: () => null,
+	loading: () => null,
 });
 
 class HomePage extends React.PureComponent {
-  constructor(props) {
-    super(props);
-    this.state = {
-      isScrollingDown: false,
-    };
-    this.timer = null;
-  }
+	constructor(props) {
+		super(props);
+		this.state = {
+			isScrollingDown: false,
+		};
+		this.timer = null;
+	}
 
-  componentDidMount() {
-    const {
-      activeFilesets,
-    } = this.props.homepage;
-    const { userSettings } = this.props;
+	componentDidMount() {
+		const { activeFilesets } = this.props.homepage;
+		const { userSettings } = this.props;
 
-    toggleWordsOfJesus(
-      userSettings.getIn(['toggleOptions', 'redLetter', 'active']),
-    );
+		toggleWordsOfJesus(
+			userSettings.getIn(['toggleOptions', 'redLetter', 'active']),
+		);
 
-    this.timer = setTimeout(() => {
-      this.getCopyrights({ filesetIds: activeFilesets });
-    }, 100);
+		this.timer = setTimeout(() => {
+			this.getCopyrights({ filesetIds: activeFilesets });
+		}, 100);
 
-    if (this.props.homepage.match.params.token) {
-      // Open Profile
-      this.toggleProfile();
-      // Give profile the token - done in render
-      // Open Password Reset Verified because there is a token - done in Profile/index
-    }
+		if (this.props.homepage.match.params.token) {
+			// Open Profile
+			this.toggleProfile();
+			// Give profile the token - done in render
+			// Open Password Reset Verified because there is a token - done in Profile/index
+		}
 
-    if (process.env.FB_APP_ID) {
-      try {
-        ((d, s, id) => {
-          let js = d.getElementsByTagName(s)[0];
-          const fjs = d.getElementsByTagName(s)[0];
-          if (d.getElementById(id)) return;
-          js = d.createElement(s);
-          js.id = id;
-          js.src = `https://connect.facebook.net/en_US/sdk.js#xfbml=1&version=v2.12&appId=${
-            process.env.FB_APP_ID
-          }&autoLogAppEvents=1`;
-          fjs.parentNode.insertBefore(js, fjs);
-        })(document, 'script', 'facebook-jssdk');
-        // Init the Facebook api here
-        if (!this.props.userId) {
-          window.fbAsyncInit = () => {
-            FB.init({
-              appId: process.env.FB_APP_ID,
-              autoLogAppEvents: true,
-              cookie: true,
-              xfbml: true,
-              version: 'v2.12',
-            });
-          };
-        }
-      } catch (err) {
-        if (process.env.NODE_ENV === 'development') {
-          console.warn('Error initializing fb api', err); // eslint-disable-line no-console
-        }
-      }
-    }
+		if (process.env.FB_APP_ID) {
+			try {
+				((d, s, id) => {
+					let js = d.getElementsByTagName(s)[0];
+					const fjs = d.getElementsByTagName(s)[0];
+					if (d.getElementById(id)) return;
+					js = d.createElement(s);
+					js.id = id;
+					js.src = `https://connect.facebook.net/en_US/sdk.js#xfbml=1&version=v2.12&appId=${process.env.FB_APP_ID}&autoLogAppEvents=1`;
+					fjs.parentNode.insertBefore(js, fjs);
+				})(document, 'script', 'facebook-jssdk');
+				// Init the Facebook api here
+				if (!this.props.userId) {
+					window.fbAsyncInit = () => {
+						FB.init({
+							appId: process.env.FB_APP_ID,
+							autoLogAppEvents: true,
+							cookie: true,
+							xfbml: true,
+							version: 'v2.12',
+						});
+					};
+				}
+			} catch (err) {
+				if (process.env.NODE_ENV === 'development') {
+					console.warn('Error initializing fb api', err); // eslint-disable-line no-console
+				}
+			}
+		}
 
-    if (process.env.GOOGLE_APP_ID) {
-      try {
-        // May need to create a script and append it to the dom then wait for it to finish loading
-        if (!this.props.userId && typeof gapi !== 'undefined') {
-          gapi.load('auth2', () => {
-            try {
-              window.auth2 = gapi.auth2.init({
-                client_id: process.env.GOOGLE_APP_ID || 'no_client',
-                scope: 'profile',
-              });
-            } catch (err) {
-              if (process.env.NODE_ENV === 'development') {
-                console.warn('Error initializing google api lower catch', err); // eslint-disable-line no-console
-              }
-            }
-          });
-        }
-      } catch (err) {
-        if (process.env.NODE_ENV === 'development') {
-          console.warn('Error initializing google api', err); // eslint-disable-line no-console
-        }
-      }
-    }
-    const videoFileset = activeFilesets.filter(
-      (f) => f.type === 'video_stream',
-    )[0];
-    this.checkForVideo(
-      videoFileset ? videoFileset.id : '',
-      this.props.homepage.activeBookId,
-      this.props.homepage.activeChapter,
-    );
-  }
+		if (process.env.GOOGLE_APP_ID) {
+			try {
+				// May need to create a script and append it to the dom then wait for it to finish loading
+				if (!this.props.userId && typeof gapi !== 'undefined') {
+					gapi.load('auth2', () => {
+						try {
+							window.auth2 = gapi.auth2.init({
+								client_id: process.env.GOOGLE_APP_ID || 'no_client',
+								scope: 'profile',
+							});
+						} catch (err) {
+							if (process.env.NODE_ENV === 'development') {
+								console.warn('Error initializing google api lower catch', err); // eslint-disable-line no-console
+							}
+						}
+					});
+				}
+			} catch (err) {
+				if (process.env.NODE_ENV === 'development') {
+					console.warn('Error initializing google api', err); // eslint-disable-line no-console
+				}
+			}
+		}
+		const videoFileset = activeFilesets.filter(
+			(f) => f.type === 'video_stream',
+		)[0];
+		this.checkForVideo(
+			videoFileset ? videoFileset.id : '',
+			this.props.homepage.activeBookId,
+			this.props.homepage.activeChapter,
+		);
+	}
 
-  componentDidUpdate(prevProps) {
-    // Based on nextProps so that requests have the latest chapter information
-    const {
-      activeTextId,
-      activeBookId,
-      activeChapter,
-      addBookmarkSuccess,
-      audioSource,
-      activeFilesets,
-    } = this.props.homepage;
-    const { userSettings, formattedSource, textData } = this.props;
-    const {
-      userSettings: prevSettings,
-      formattedSource: prevFormattedSource,
-      textData: prevTextData,
-    } = prevProps;
-    const { userId, userAuthenticated } = this.props.profile;
-    const {
-      addBookmarkSuccess: addBookmarkSuccessProps,
-      activeTextId: activeTextIdProps,
-      activeBookId: activeBookIdProps,
-      activeChapter: activeChapterProps,
-      audioSource: prevAudioSource,
-    } = prevProps.homepage;
-    const {
-      userId: userIdProps,
-      userAuthenticated: userAuthenticatedProps,
-    } = prevProps.profile;
-    const prevVerseNumber = prevProps.homepage.match.params.verse;
-    const verseNumber = this.props.homepage.match.params.verse;
-    const audioParam =
-      location &&
-      location.search &&
-      location.search
-        .slice(1)
-        .split('&')
-        .map((key) => key.split('='))
-        .find((key) => key[0] === 'audio_type');
-    if (
-      audioParam &&
-      (audioParam[1] !== prevProps.homepage.audioType ||
-        audioParam[1] !== this.props.homepage.audioType)
-    ) {
-      prevProps.dispatch(setAudioType({ audioType: audioParam[1] }));
-    }
+	componentDidUpdate(prevProps) {
+		// Based on nextProps so that requests have the latest chapter information
+		const {
+			activeTextId,
+			activeBookId,
+			activeChapter,
+			addBookmarkSuccess,
+			audioSource,
+			activeFilesets,
+		} = this.props.homepage;
+		const { userSettings, formattedSource, textData } = this.props;
+		const {
+			userSettings: prevSettings,
+			formattedSource: prevFormattedSource,
+			textData: prevTextData,
+		} = prevProps;
+		const { userId, userAuthenticated } = this.props.profile;
+		const {
+			addBookmarkSuccess: addBookmarkSuccessProps,
+			activeTextId: activeTextIdProps,
+			activeBookId: activeBookIdProps,
+			activeChapter: activeChapterProps,
+			audioSource: prevAudioSource,
+		} = prevProps.homepage;
+		const { userId: userIdProps, userAuthenticated: userAuthenticatedProps } =
+			prevProps.profile;
+		const prevVerseNumber = prevProps.homepage.match.params.verse;
+		const verseNumber = this.props.homepage.match.params.verse;
+		const audioParam =
+			location?.search &&
+			location.search
+				.slice(1)
+				.split('&')
+				.map((key) => key.split('='))
+				.find((key) => key[0] === 'audio_type');
+		if (
+			audioParam &&
+			(audioParam[1] !== prevProps.homepage.audioType ||
+				audioParam[1] !== this.props.homepage.audioType)
+		) {
+			prevProps.dispatch(setAudioType({ audioType: audioParam[1] }));
+		}
 
-    if (this.props.homepage.changingVersion) {
-      this.props.dispatch(changeVersion({ state: false }));
-    }
+		if (this.props.homepage.changingVersion) {
+			this.props.dispatch(changeVersion({ state: false }));
+		}
 
-    // If there was a change in the params then make sure loading state is set to false
-    if (
-      prevVerseNumber !== verseNumber ||
-      formattedSource.main !== prevFormattedSource.main ||
-      !isEqual(prevTextData.text, textData.text) ||
-      audioSource !== prevAudioSource ||
-      activeChapter !== activeChapterProps
-    ) {
-      this.setTextLoadingState({ state: false });
-      this.getCopyrights({ filesetIds: activeFilesets });
-    }
+		// If there was a change in the params then make sure loading state is set to false
+		if (
+			prevVerseNumber !== verseNumber ||
+			formattedSource.main !== prevFormattedSource.main ||
+			!isEqual(prevTextData.text, textData.text) ||
+			audioSource !== prevAudioSource ||
+			activeChapter !== activeChapterProps
+		) {
+			this.setTextLoadingState({ state: false });
+			this.getCopyrights({ filesetIds: activeFilesets });
+		}
 
-    // Only apply the them if one of them changed - use the newest one always since that will be what the user clicked
-    if (typeof document !== 'undefined') {
-      if (
-        prevSettings.getIn(['toggleOptions', 'redLetter', 'active']) !==
-        userSettings.getIn(['toggleOptions', 'redLetter', 'active'])
-      ) {
-        toggleWordsOfJesus(
-          userSettings.getIn(['toggleOptions', 'redLetter', 'active']),
-        );
-      }
-      if (prevSettings.get('activeTheme') !== userSettings.get('activeTheme')) {
-        applyTheme(userSettings.get('activeTheme'));
-      }
-      if (
-        prevSettings.get('activeFontType') !==
-        userSettings.get('activeFontType')
-      ) {
-        applyFontFamily(userSettings.get('activeFontType'));
-      }
-      if (
-        prevSettings.get('activeFontSize') !==
-        userSettings.get('activeFontSize')
-      ) {
-        applyFontSize(userSettings.get('activeFontSize'));
-      }
-    }
-    // If there is an authenticated user then send these calls
-    if (
-      userId &&
-      userAuthenticated &&
-      (userId !== userIdProps ||
-        userAuthenticated !== userAuthenticatedProps ||
-        activeTextId !== activeTextIdProps ||
-        activeBookId !== activeBookIdProps ||
-        activeChapter !== activeChapterProps)
-    ) {
-      // Should move all of these into the same call to reduce the number of renders in the text component
-      this.props.dispatch(
-        getHighlights({
-          bible: activeTextId,
-          book: activeBookId,
-          chapter: activeChapter,
-          userAuthenticated,
-          userId,
-        }),
-      );
-      this.props.dispatch(
-        getNotes({
-          userId,
-          params: {
-            bible_id: activeTextId,
-            book_id: activeBookId,
-            chapter: activeChapter,
-            limit: 150,
-            page: 1,
-          },
-        }),
-      );
+		// Only apply the them if one of them changed - use the newest one always since that will be what the user clicked
+		if (typeof document !== 'undefined') {
+			if (
+				prevSettings.getIn(['toggleOptions', 'redLetter', 'active']) !==
+				userSettings.getIn(['toggleOptions', 'redLetter', 'active'])
+			) {
+				toggleWordsOfJesus(
+					userSettings.getIn(['toggleOptions', 'redLetter', 'active']),
+				);
+			}
+			if (prevSettings.get('activeTheme') !== userSettings.get('activeTheme')) {
+				applyTheme(userSettings.get('activeTheme'));
+			}
+			if (
+				prevSettings.get('activeFontType') !==
+				userSettings.get('activeFontType')
+			) {
+				applyFontFamily(userSettings.get('activeFontType'));
+			}
+			if (
+				prevSettings.get('activeFontSize') !==
+				userSettings.get('activeFontSize')
+			) {
+				applyFontSize(userSettings.get('activeFontSize'));
+			}
+		}
+		// If there is an authenticated user then send these calls
+		if (
+			userId &&
+			userAuthenticated &&
+			(userId !== userIdProps ||
+				userAuthenticated !== userAuthenticatedProps ||
+				activeTextId !== activeTextIdProps ||
+				activeBookId !== activeBookIdProps ||
+				activeChapter !== activeChapterProps)
+		) {
+			// Should move all of these into the same call to reduce the number of renders in the text component
+			this.props.dispatch(
+				getHighlights({
+					bible: activeTextId,
+					book: activeBookId,
+					chapter: activeChapter,
+					userAuthenticated,
+					userId,
+				}),
+			);
+			this.props.dispatch(
+				getNotes({
+					userId,
+					params: {
+						bible_id: activeTextId,
+						book_id: activeBookId,
+						chapter: activeChapter,
+						limit: 150,
+						page: 1,
+					},
+				}),
+			);
 
-      this.props.dispatch(
-        getBookmarksForChapter({
-          userId,
-          params: {
-            bible_id: activeTextId,
-            book_id: activeBookId,
-            chapter: activeChapter,
-            limit: 150,
-            page: 1,
-          },
-        }),
-      );
-    }
+			this.props.dispatch(
+				getBookmarksForChapter({
+					userId,
+					params: {
+						bible_id: activeTextId,
+						book_id: activeBookId,
+						chapter: activeChapter,
+						limit: 150,
+						page: 1,
+					},
+				}),
+			);
+		}
 
-    if (addBookmarkSuccess !== addBookmarkSuccessProps && addBookmarkSuccess) {
-      this.props.dispatch(
-        getBookmarksForChapter({
-          userId,
-          params: {
-            bible_id: activeTextId,
-            book_id: activeBookId,
-            chapter: activeChapter,
-            limit: 150,
-            page: 1,
-          },
-        }),
-      );
-      this.props.dispatch(resetBookmarkState());
-    }
+		if (addBookmarkSuccess !== addBookmarkSuccessProps && addBookmarkSuccess) {
+			this.props.dispatch(
+				getBookmarksForChapter({
+					userId,
+					params: {
+						bible_id: activeTextId,
+						book_id: activeBookId,
+						chapter: activeChapter,
+						limit: 150,
+						page: 1,
+					},
+				}),
+			);
+			this.props.dispatch(resetBookmarkState());
+		}
 
-    if (this.props.homepage.firstLoad) {
-      this.toggleFirstLoadForTextSelection();
-    }
+		if (this.props.homepage.firstLoad) {
+			this.toggleFirstLoadForTextSelection();
+		}
 
-    if (!this.props.homepage.firstLoad && prevProps.homepage.firstLoad) {
-      // this.props.dispatch(
-      //   setActiveIsoCode({
-      //     iso: this.props.homepage.initialIsoCode,
-      //     languageCode: this.props.homepage.defaultLanguageCode,
-      //     name: this.props.homepage.initialLanguageName,
-      //   }),
-      // );
+		if (!this.props.homepage.firstLoad && prevProps.homepage.firstLoad) {
+			// this.props.dispatch(
+			//   setActiveIsoCode({
+			//     iso: this.props.homepage.initialIsoCode,
+			//     languageCode: this.props.homepage.defaultLanguageCode,
+			//     name: this.props.homepage.initialLanguageName,
+			//   }),
+			// );
 
-      this.props.dispatch(
-        initApplication({
-          languageIso: this.props.homepage.defaultLanguageIso,
-          languageCode: this.props.homepage.defaultLanguageCode,
-        }),
-      );
-    }
-  }
+			this.props.dispatch(
+				initApplication({
+					languageIso: this.props.homepage.defaultLanguageIso,
+					languageCode: this.props.homepage.defaultLanguageCode,
+				}),
+			);
+		}
+	}
 
-  componentWillUnmount() {
-    clearTimeout(this.timer);
-  }
+	componentWillUnmount() {
+		clearTimeout(this.timer);
+	}
 
-  getCopyrights = (props) => this.props.dispatch(getCopyrights(props));
+	getCopyrights = (props) => this.props.dispatch(getCopyrights(props));
 
-  setTextLoadingState = (props) =>
-    this.props.dispatch(setChapterTextLoadingState(props));
+	setTextLoadingState = (props) =>
+		this.props.dispatch(setChapterTextLoadingState(props));
 
-  checkForVideo = async (filesetId, bookId, chapter) => {
-    if (!filesetId) {
-      this.props.dispatch(
-        setHasVideo({
-          state: false,
-          videoChapterState: false,
-          videoPlayerOpen: false,
-        }),
-      );
-      return;
-    }
-    const hasVideo = await checkForVideoAsync(filesetId, bookId, chapter);
+	checkForVideo = async (filesetId, bookId, chapter) => {
+		if (!filesetId) {
+			this.props.dispatch(
+				setHasVideo({
+					state: false,
+					videoChapterState: false,
+					videoPlayerOpen: false,
+				}),
+			);
+			return;
+		}
+		const hasVideo = await checkForVideoAsync(filesetId, bookId, chapter);
 
-    this.props.dispatch(
-      setHasVideo({
-        state: hasVideo,
-        videoChapterState: hasVideo,
-        videoPlayerOpen: hasVideo,
-      }),
-    );
-  };
+		this.props.dispatch(
+			setHasVideo({
+				state: hasVideo,
+				videoChapterState: hasVideo,
+				videoPlayerOpen: hasVideo,
+			}),
+		);
+	};
 
-  toggleFirstLoadForTextSelection = () =>
-    this.props.homepage.firstLoad &&
-    this.props.dispatch(toggleFirstLoadForTextSelection());
+	toggleFirstLoadForTextSelection = () =>
+		this.props.homepage.firstLoad &&
+		this.props.dispatch(toggleFirstLoadForTextSelection());
 
-  toggleProfile = () => {
-    this.props.dispatch(toggleProfile());
-  };
+	toggleProfile = () => {
+		this.props.dispatch(toggleProfile());
+	};
 
-  toggleNotesModal = () => {
-    this.props.dispatch(toggleNotesModal());
-  };
+	toggleNotesModal = () => {
+		this.props.dispatch(toggleNotesModal());
+	};
 
-  toggleSettingsModal = () => {
-    this.props.dispatch(toggleSettingsModal());
-  };
+	toggleSettingsModal = () => {
+		this.props.dispatch(toggleSettingsModal());
+	};
 
-  toggleSearchModal = () => {
-    this.props.dispatch(toggleSearchModal());
-  };
+	toggleSearchModal = () => {
+		this.props.dispatch(toggleSearchModal());
+	};
 
-  toggleChapterSelection = () => {
-    this.props.dispatch(toggleChapterSelection());
-  };
+	toggleChapterSelection = () => {
+		this.props.dispatch(toggleChapterSelection());
+	};
 
-  toggleVersionSelection = () => {
-    this.props.dispatch(toggleVersionSelection());
-  };
+	toggleVersionSelection = () => {
+		this.props.dispatch(toggleVersionSelection());
+	};
 
-  render() {
-    const {
-      activeBookId,
-      activeTextId,
-      activeChapter,
-      activeBookName,
-      activeFilesets,
-      activeTextName,
-      activeFilesetId,
-      audioPlayerState,
-      books,
-      isProfileActive,
-      isNotesModalActive,
-      isSearchModalActive,
-      isSettingsModalActive,
-      isVersionSelectionActive,
-      isChapterSelectionActive,
-      userAgent,
-      loadingAudio,
-      loadingNewChapterText,
-      chapterTextLoadingState,
-      changingVersion,
-      videoPlayerOpen,
-      hasVideo,
-      audioType,
-      textDirection,
-    } = this.props.homepage;
+	render() {
+		const {
+			activeBookId,
+			activeTextId,
+			activeChapter,
+			activeBookName,
+			activeFilesets,
+			activeTextName,
+			activeFilesetId,
+			audioPlayerState,
+			books,
+			isProfileActive,
+			isNotesModalActive,
+			isSearchModalActive,
+			isSettingsModalActive,
+			isVersionSelectionActive,
+			isChapterSelectionActive,
+			userAgent,
+			loadingAudio,
+			loadingNewChapterText,
+			chapterTextLoadingState,
+			changingVersion,
+			videoPlayerOpen,
+			hasVideo,
+			audioType,
+			textDirection,
+		} = this.props.homepage;
 
-    const { userSettings, isMenuOpen, isIe, activeNotesView } = this.props;
+		const { userSettings, isMenuOpen, isIe, activeNotesView } = this.props;
 
-    const { isScrollingDown } = this.state;
-    const { text: updatedText } = this.props.textData;
-    const token = this.props.homepage.match.params.token || '';
-    const verse = this.props.homepage.match.params.verse || '';
+		const { isScrollingDown } = this.state;
+		const { text: updatedText } = this.props.textData;
+		const token = this.props.homepage.match.params.token || '';
+		const verse = this.props.homepage.match.params.verse || '';
 
-    return (
-      <>
-        <NavigationBar
-          userAgent={userAgent}
-          activeTextId={activeTextId}
-          activeChapter={activeChapter}
-          activeTextName={activeTextName}
-          activeBookName={activeBookName}
-          textDirection={textDirection}
-          theme={userSettings.get('activeTheme')}
-          isScrollingDown={isScrollingDown}
-          isChapterSelectionActive={isChapterSelectionActive}
-          isVersionSelectionActive={isVersionSelectionActive}
-          toggleChapterSelection={this.toggleChapterSelection}
-          toggleVersionSelection={this.toggleVersionSelection}
-        />
-        <div
-          className={
-            videoPlayerOpen || !audioPlayerState
-              ? 'content-container audio-closed'
-              : 'content-container'
-          }
-        >
-          {(activeTextId && (
-              <VideoPlayer
-                fileset={
-                  activeFilesets.filter((f) => f.type === 'video_stream')[0]
-                }
-                bookId={activeBookId}
-                chapter={activeChapter}
-                books={books}
-                text={updatedText}
-                textId={activeTextId}
-              />
-            )
-          )}
-          { activeTextId && (
-              <Text
-              books={books}
-              text={updatedText}
-              hasVideo={hasVideo}
-              verseNumber={verse}
-              audioType={audioType}
-              menuIsOpen={isMenuOpen}
-              activeTextId={activeTextId}
-              activeBookId={activeBookId}
-              loadingAudio={loadingAudio}
-              activeChapter={activeChapter}
-              changingVersion={changingVersion}
-              videoPlayerOpen={videoPlayerOpen}
-              isScrollingDown={isScrollingDown}
-              audioPlayerState={audioPlayerState}
-              loadingNewChapterText={loadingNewChapterText}
-              chapterTextLoadingState={chapterTextLoadingState}
-              />
-          )}
-        </div>
-        <TransitionGroup>
-          {isSettingsModalActive ? (
-            <FadeTransition
-              classNames="slide-from-right"
-              in={isSettingsModalActive}
-            >
-              <Settings
-                userSettings={userSettings}
-                toggleSettingsModal={this.toggleSettingsModal}
-                isIe={isIe}
-              />
-            </FadeTransition>
-          ) : null}
-          {isProfileActive ? (
-            <FadeTransition classNames="slide-from-left" in={isProfileActive}>
-              <Profile
-                resetPasswordSent={this.resetPasswordSent}
-                userAccessToken={token}
-                toggleProfile={this.toggleProfile}
-                isIe={isIe}
-              />
-            </FadeTransition>
-          ) : null}
-          {isNotesModalActive ? (
-            <FadeTransition
-              classNames="slide-from-right"
-              in={isNotesModalActive}
-            >
-              <Notes
-                activeBookId={activeBookId}
-                activeChapter={activeChapter}
-                toggleProfile={this.toggleProfile}
-                toggleNotesModal={this.toggleNotesModal}
-                openView={activeNotesView}
-                isIe={isIe}
-              />
-            </FadeTransition>
-          ) : null}
-          {isSearchModalActive ? (
-            <FadeTransition
-              classNames="slide-from-left"
-              in={isSearchModalActive}
-            >
-              <SearchContainer
-                bibleId={activeTextId}
-                activeFilesetId={activeFilesetId}
-                books={books}
-                toggleSearchModal={this.toggleSearchModal}
-                isIe={isIe}
-              />
-            </FadeTransition>
-          ) : null}
-        </TransitionGroup>
-        {activeTextId && <AudioPlayer verseNumber={verse} audioType={audioType} />}
-        <Footer
-          profileActive={isProfileActive}
-          searchActive={isSearchModalActive}
-          notebookActive={isNotesModalActive}
-          settingsActive={isSettingsModalActive}
-          isScrollingDown={isScrollingDown}
-          toggleProfile={this.toggleProfile}
-          toggleSearch={this.toggleSearchModal}
-          toggleNotebook={this.toggleNotesModal}
-          toggleSettingsModal={this.toggleSettingsModal}
-        />
-      </>
-    );
-  }
+		return (
+			<>
+				<NavigationBar
+					userAgent={userAgent}
+					activeTextId={activeTextId}
+					activeChapter={activeChapter}
+					activeTextName={activeTextName}
+					activeBookName={activeBookName}
+					textDirection={textDirection}
+					theme={userSettings.get('activeTheme')}
+					isScrollingDown={isScrollingDown}
+					isChapterSelectionActive={isChapterSelectionActive}
+					isVersionSelectionActive={isVersionSelectionActive}
+					toggleChapterSelection={this.toggleChapterSelection}
+					toggleVersionSelection={this.toggleVersionSelection}
+				/>
+				<div
+					className={
+						videoPlayerOpen || !audioPlayerState
+							? 'content-container audio-closed'
+							: 'content-container'
+					}
+				>
+					{activeTextId && (
+						<VideoPlayer
+							fileset={
+								activeFilesets.filter((f) => f.type === 'video_stream')[0]
+							}
+							bookId={activeBookId}
+							chapter={activeChapter}
+							books={books}
+							text={updatedText}
+							textId={activeTextId}
+						/>
+					)}
+					{activeTextId && (
+						<Text
+							books={books}
+							text={updatedText}
+							hasVideo={hasVideo}
+							verseNumber={verse}
+							audioType={audioType}
+							menuIsOpen={isMenuOpen}
+							activeTextId={activeTextId}
+							activeBookId={activeBookId}
+							loadingAudio={loadingAudio}
+							activeChapter={activeChapter}
+							changingVersion={changingVersion}
+							videoPlayerOpen={videoPlayerOpen}
+							isScrollingDown={isScrollingDown}
+							audioPlayerState={audioPlayerState}
+							loadingNewChapterText={loadingNewChapterText}
+							chapterTextLoadingState={chapterTextLoadingState}
+						/>
+					)}
+				</div>
+				<TransitionGroup>
+					{isSettingsModalActive ? (
+						<FadeTransition
+							classNames="slide-from-right"
+							in={isSettingsModalActive}
+						>
+							<Settings
+								userSettings={userSettings}
+								toggleSettingsModal={this.toggleSettingsModal}
+								isIe={isIe}
+							/>
+						</FadeTransition>
+					) : null}
+					{isProfileActive ? (
+						<FadeTransition classNames="slide-from-left" in={isProfileActive}>
+							<Profile
+								resetPasswordSent={this.resetPasswordSent}
+								userAccessToken={token}
+								toggleProfile={this.toggleProfile}
+								isIe={isIe}
+							/>
+						</FadeTransition>
+					) : null}
+					{isNotesModalActive ? (
+						<FadeTransition
+							classNames="slide-from-right"
+							in={isNotesModalActive}
+						>
+							<Notes
+								activeBookId={activeBookId}
+								activeChapter={activeChapter}
+								toggleProfile={this.toggleProfile}
+								toggleNotesModal={this.toggleNotesModal}
+								openView={activeNotesView}
+								isIe={isIe}
+							/>
+						</FadeTransition>
+					) : null}
+					{isSearchModalActive ? (
+						<FadeTransition
+							classNames="slide-from-left"
+							in={isSearchModalActive}
+						>
+							<SearchContainer
+								bibleId={activeTextId}
+								activeFilesetId={activeFilesetId}
+								books={books}
+								toggleSearchModal={this.toggleSearchModal}
+								isIe={isIe}
+							/>
+						</FadeTransition>
+					) : null}
+				</TransitionGroup>
+				{activeTextId && (
+					<AudioPlayer verseNumber={verse} audioType={audioType} />
+				)}
+				<Footer
+					profileActive={isProfileActive}
+					searchActive={isSearchModalActive}
+					notebookActive={isNotesModalActive}
+					settingsActive={isSettingsModalActive}
+					isScrollingDown={isScrollingDown}
+					toggleProfile={this.toggleProfile}
+					toggleSearch={this.toggleSearchModal}
+					toggleNotebook={this.toggleNotesModal}
+					toggleSettingsModal={this.toggleSettingsModal}
+				/>
+			</>
+		);
+	}
 }
 
 HomePage.propTypes = {
-  dispatch: PropTypes.func.isRequired,
-  homepage: PropTypes.shape({
-    activeBookId: PropTypes.string,
-    activeTextId: PropTypes.string.isRequired,
-    activeChapter: PropTypes.number,
-    activeBookName: PropTypes.string,
-    activeFilesets: PropTypes.array,
-    activeTextName: PropTypes.string,
-    activeFilesetId: PropTypes.string,
-    audioPlayerState: PropTypes.bool,
-    books: PropTypes.array,
-    isProfileActive: PropTypes.bool,
-    isNotesModalActive: PropTypes.bool,
-    isSearchModalActive: PropTypes.bool,
-    isSettingsModalActive: PropTypes.bool,
-    isVersionSelectionActive: PropTypes.bool,
-    isChapterSelectionActive: PropTypes.bool,
-    userAgent: PropTypes.string,
-    loadingAudio: PropTypes.bool,
-    loadingNewChapterText: PropTypes.bool,
-    chapterTextLoadingState: PropTypes.bool,
-    changingVersion: PropTypes.bool,
-    videoPlayerOpen: PropTypes.bool,
-    hasVideo: PropTypes.bool,
-    audioType: PropTypes.string,
-    textDirection: PropTypes.string,
-    match: PropTypes.object,
-    firstLoad: PropTypes.bool,
-    addBookmarkSuccess: PropTypes.bool,
-    defaultLanguageIso: PropTypes.string,
-    defaultLanguageCode: PropTypes.number,
-    audioSource: PropTypes.string,
-  }).isRequired,
-  userSettings: PropTypes.object,
-  formattedSource: PropTypes.object,
-  userAuthenticated: PropTypes.bool,
-  isIe: PropTypes.bool,
-  activeNotesView: PropTypes.string,
-  userId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-  textData: PropTypes.object,
-  isMenuOpen: PropTypes.bool,
-  profile: PropTypes.object,
+	dispatch: PropTypes.func.isRequired,
+	homepage: PropTypes.shape({
+		activeBookId: PropTypes.string,
+		activeTextId: PropTypes.string.isRequired,
+		activeChapter: PropTypes.number,
+		activeBookName: PropTypes.string,
+		activeFilesets: PropTypes.array,
+		activeTextName: PropTypes.string,
+		activeFilesetId: PropTypes.string,
+		audioPlayerState: PropTypes.bool,
+		books: PropTypes.array,
+		isProfileActive: PropTypes.bool,
+		isNotesModalActive: PropTypes.bool,
+		isSearchModalActive: PropTypes.bool,
+		isSettingsModalActive: PropTypes.bool,
+		isVersionSelectionActive: PropTypes.bool,
+		isChapterSelectionActive: PropTypes.bool,
+		userAgent: PropTypes.string,
+		loadingAudio: PropTypes.bool,
+		loadingNewChapterText: PropTypes.bool,
+		chapterTextLoadingState: PropTypes.bool,
+		changingVersion: PropTypes.bool,
+		videoPlayerOpen: PropTypes.bool,
+		hasVideo: PropTypes.bool,
+		audioType: PropTypes.string,
+		textDirection: PropTypes.string,
+		match: PropTypes.object,
+		firstLoad: PropTypes.bool,
+		addBookmarkSuccess: PropTypes.bool,
+		defaultLanguageIso: PropTypes.string,
+		defaultLanguageCode: PropTypes.number,
+		audioSource: PropTypes.string,
+	}).isRequired,
+	userSettings: PropTypes.object,
+	formattedSource: PropTypes.object,
+	userAuthenticated: PropTypes.bool,
+	isIe: PropTypes.bool,
+	activeNotesView: PropTypes.string,
+	userId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+	textData: PropTypes.object,
+	isMenuOpen: PropTypes.bool,
+	profile: PropTypes.object,
 };
 
 const mapStateToProps = createStructuredSelector({
-  homepage: makeSelectHomePage(),
-  formattedSource: selectFormattedSource(),
-  userAuthenticated: selectAuthenticationStatus(),
-  userId: selectUserId(),
-  textData: selectUserNotes(),
-  profile: makeSelectProfile(),
-  isMenuOpen: selectMenuOpenState(),
-  userSettings: selectSettings(),
-  activeNotesView: selectActiveNotesView(),
+	homepage: makeSelectHomePage(),
+	formattedSource: selectFormattedSource(),
+	userAuthenticated: selectAuthenticationStatus(),
+	userId: selectUserId(),
+	textData: selectUserNotes(),
+	profile: makeSelectProfile(),
+	isMenuOpen: selectMenuOpenState(),
+	userSettings: selectSettings(),
+	activeNotesView: selectActiveNotesView(),
 });
 
 function mapDispatchToProps(dispatch) {
-  return {
-    dispatch,
-  };
+	return {
+		dispatch,
+	};
 }
 
-const withConnect = connect(
-  mapStateToProps,
-  mapDispatchToProps,
-);
+const withConnect = connect(mapStateToProps, mapDispatchToProps);
 
 // Defeats the purpose of code splitting - need to figure out a different method to reduce bundle size
 const withReducer = injectReducer({ key: 'homepage', reducer });
 const withSaga = injectSaga({ key: 'homepage', saga });
 const withTextReducer = injectReducer({
-  key: 'textSelection',
-  reducer: textReducer,
+	key: 'textSelection',
+	reducer: textReducer,
 });
 const withTextSaga = injectSaga({ key: 'textSelection', saga: textSaga });
 const withNotesSaga = injectSaga({ key: 'notes', saga: notesSaga });
 const withNotesReducer = injectReducer({ key: 'notes', reducer: notesReducer });
 const withProfileReducer = injectReducer({
-  key: 'profile',
-  reducer: profileReducer,
+	key: 'profile',
+	reducer: profileReducer,
 });
 const withProfileSaga = injectSaga({ key: 'profile', saga: profileSaga });
 const withSettingsReducer = injectReducer({
-  key: 'settings',
-  reducer: settingsReducer,
+	key: 'settings',
+	reducer: settingsReducer,
 });
 
 export default compose(
-  withReducer,
-  withTextReducer,
-  withProfileReducer,
-  withProfileSaga,
-  withNotesReducer,
-  withSaga,
-  withNotesSaga,
-  withTextSaga,
-  withSettingsReducer,
-  withConnect,
+	withReducer,
+	withTextReducer,
+	withProfileReducer,
+	withProfileSaga,
+	withNotesReducer,
+	withSaga,
+	withNotesSaga,
+	withTextSaga,
+	withSettingsReducer,
+	withConnect,
 )(HomePage);

--- a/app/containers/HomePage/index.js
+++ b/app/containers/HomePage/index.js
@@ -31,633 +31,641 @@ import makeSelectProfile from '../Profile/selectors';
 import { getBookmarksForChapter } from '../Notes/actions';
 import { setHasVideo } from '../VideoPlayer/actions';
 import {
-	getNotes,
-	getHighlights,
-	getCopyrights,
-	toggleProfile,
-	toggleNotesModal,
-	toggleSearchModal,
-	toggleSettingsModal,
-	toggleChapterSelection,
-	toggleVersionSelection,
-	toggleFirstLoadForTextSelection,
-	setChapterTextLoadingState,
-	resetBookmarkState,
-	initApplication,
-	changeVersion,
+  getNotes,
+  getHighlights,
+  getCopyrights,
+  toggleProfile,
+  toggleNotesModal,
+  toggleSearchModal,
+  toggleSettingsModal,
+  toggleChapterSelection,
+  toggleVersionSelection,
+  toggleFirstLoadForTextSelection,
+  setChapterTextLoadingState,
+  resetBookmarkState,
+  initApplication,
+  changeVersion,
 } from './actions';
 import makeSelectHomePage, {
-	selectSettings,
-	selectFormattedSource,
-	selectAuthenticationStatus,
-	selectUserId,
-	selectMenuOpenState,
-	selectUserNotes,
-	selectActiveNotesView,
+  selectSettings,
+  selectFormattedSource,
+  selectAuthenticationStatus,
+  selectUserId,
+  selectMenuOpenState,
+  selectUserNotes,
+  selectActiveNotesView,
 } from './selectors';
 import reducer from './reducer';
 import saga from './saga';
 import {
-	applyTheme,
-	applyFontFamily,
-	applyFontSize,
-	toggleWordsOfJesus,
+  applyTheme,
+  applyFontFamily,
+  applyFontSize,
+  toggleWordsOfJesus,
 } from '../Settings/themes';
 import { setAudioType } from '../AudioPlayer/actions';
 
 const VideoPlayer = dynamic(import('../VideoPlayer'), {
-	loading: () => null,
+  loading: () => null,
 });
 const Profile = dynamic(import('../Profile'), {
-	loading: () => null,
+  loading: () => null,
 });
 const Settings = dynamic(import('../Settings'), {
-	loading: () => null,
+  loading: () => null,
 });
 const SearchContainer = dynamic(import('../SearchContainer'), {
-	loading: () => null,
+  loading: () => null,
 });
 const Notes = dynamic(import('../Notes'), {
-	loading: () => null,
+  loading: () => null,
 });
 
 class HomePage extends React.PureComponent {
-	constructor(props) {
-		super(props);
-		this.state = {
-			isScrollingDown: false,
-		};
-		this.timer = null;
-	}
+  constructor(props) {
+    super(props);
+    this.state = {
+      isScrollingDown: false,
+    };
+    this.timer = null;
+  }
 
-	componentDidMount() {
-		const { activeFilesets } = this.props.homepage;
-		const { userSettings } = this.props;
+  componentDidMount() {
+    const {
+      activeFilesets,
+    } = this.props.homepage;
+    const { userSettings } = this.props;
 
-		toggleWordsOfJesus(
-			userSettings.getIn(['toggleOptions', 'redLetter', 'active']),
-		);
+    toggleWordsOfJesus(
+      userSettings.getIn(['toggleOptions', 'redLetter', 'active']),
+    );
 
-		this.timer = setTimeout(() => {
-			this.getCopyrights({ filesetIds: activeFilesets });
-		}, 100);
+    this.timer = setTimeout(() => {
+      this.getCopyrights({ filesetIds: activeFilesets });
+    }, 100);
 
-		if (this.props.homepage.match.params.token) {
-			// Open Profile
-			this.toggleProfile();
-			// Give profile the token - done in render
-			// Open Password Reset Verified because there is a token - done in Profile/index
-		}
+    if (this.props.homepage.match.params.token) {
+      // Open Profile
+      this.toggleProfile();
+      // Give profile the token - done in render
+      // Open Password Reset Verified because there is a token - done in Profile/index
+    }
 
-		if (process.env.FB_APP_ID) {
-			try {
-				((d, s, id) => {
-					let js = d.getElementsByTagName(s)[0];
-					const fjs = d.getElementsByTagName(s)[0];
-					if (d.getElementById(id)) return;
-					js = d.createElement(s);
-					js.id = id;
-					js.src = `https://connect.facebook.net/en_US/sdk.js#xfbml=1&version=v2.12&appId=${process.env.FB_APP_ID}&autoLogAppEvents=1`;
-					fjs.parentNode.insertBefore(js, fjs);
-				})(document, 'script', 'facebook-jssdk');
-				// Init the Facebook api here
-				if (!this.props.userId) {
-					window.fbAsyncInit = () => {
-						FB.init({
-							appId: process.env.FB_APP_ID,
-							autoLogAppEvents: true,
-							cookie: true,
-							xfbml: true,
-							version: 'v2.12',
-						});
-					};
-				}
-			} catch (err) {
-				if (process.env.NODE_ENV === 'development') {
-					console.warn('Error initializing fb api', err); // eslint-disable-line no-console
-				}
-			}
-		}
+    if (process.env.FB_APP_ID) {
+      try {
+        ((d, s, id) => {
+          let js = d.getElementsByTagName(s)[0];
+          const fjs = d.getElementsByTagName(s)[0];
+          if (d.getElementById(id)) return;
+          js = d.createElement(s);
+          js.id = id;
+          js.src = `https://connect.facebook.net/en_US/sdk.js#xfbml=1&version=v2.12&appId=${
+            process.env.FB_APP_ID
+          }&autoLogAppEvents=1`;
+          fjs.parentNode.insertBefore(js, fjs);
+        })(document, 'script', 'facebook-jssdk');
+        // Init the Facebook api here
+        if (!this.props.userId) {
+          window.fbAsyncInit = () => {
+            FB.init({
+              appId: process.env.FB_APP_ID,
+              autoLogAppEvents: true,
+              cookie: true,
+              xfbml: true,
+              version: 'v2.12',
+            });
+          };
+        }
+      } catch (err) {
+        if (process.env.NODE_ENV === 'development') {
+          console.warn('Error initializing fb api', err); // eslint-disable-line no-console
+        }
+      }
+    }
 
-		if (process.env.GOOGLE_APP_ID) {
-			try {
-				// May need to create a script and append it to the dom then wait for it to finish loading
-				if (!this.props.userId && typeof gapi !== 'undefined') {
-					gapi.load('auth2', () => {
-						try {
-							window.auth2 = gapi.auth2.init({
-								client_id: process.env.GOOGLE_APP_ID || 'no_client',
-								scope: 'profile',
-							});
-						} catch (err) {
-							if (process.env.NODE_ENV === 'development') {
-								console.warn('Error initializing google api lower catch', err); // eslint-disable-line no-console
-							}
-						}
-					});
-				}
-			} catch (err) {
-				if (process.env.NODE_ENV === 'development') {
-					console.warn('Error initializing google api', err); // eslint-disable-line no-console
-				}
-			}
-		}
-		const videoFileset = activeFilesets.filter(
-			(f) => f.type === 'video_stream',
-		)[0];
-		this.checkForVideo(
-			videoFileset ? videoFileset.id : '',
-			this.props.homepage.activeBookId,
-			this.props.homepage.activeChapter,
-		);
-	}
+    if (process.env.GOOGLE_APP_ID) {
+      try {
+        // May need to create a script and append it to the dom then wait for it to finish loading
+        if (!this.props.userId && typeof gapi !== 'undefined') {
+          gapi.load('auth2', () => {
+            try {
+              window.auth2 = gapi.auth2.init({
+                client_id: process.env.GOOGLE_APP_ID || 'no_client',
+                scope: 'profile',
+              });
+            } catch (err) {
+              if (process.env.NODE_ENV === 'development') {
+                console.warn('Error initializing google api lower catch', err); // eslint-disable-line no-console
+              }
+            }
+          });
+        }
+      } catch (err) {
+        if (process.env.NODE_ENV === 'development') {
+          console.warn('Error initializing google api', err); // eslint-disable-line no-console
+        }
+      }
+    }
+    const videoFileset = activeFilesets.filter(
+      (f) => f.type === 'video_stream',
+    )[0];
+    this.checkForVideo(
+      videoFileset ? videoFileset.id : '',
+      this.props.homepage.activeBookId,
+      this.props.homepage.activeChapter,
+    );
+  }
 
-	componentDidUpdate(prevProps) {
-		// Based on nextProps so that requests have the latest chapter information
-		const {
-			activeTextId,
-			activeBookId,
-			activeChapter,
-			addBookmarkSuccess,
-			audioSource,
-			activeFilesets,
-		} = this.props.homepage;
-		const { userSettings, formattedSource, textData } = this.props;
-		const {
-			userSettings: prevSettings,
-			formattedSource: prevFormattedSource,
-			textData: prevTextData,
-		} = prevProps;
-		const { userId, userAuthenticated } = this.props.profile;
-		const {
-			addBookmarkSuccess: addBookmarkSuccessProps,
-			activeTextId: activeTextIdProps,
-			activeBookId: activeBookIdProps,
-			activeChapter: activeChapterProps,
-			audioSource: prevAudioSource,
-		} = prevProps.homepage;
-		const { userId: userIdProps, userAuthenticated: userAuthenticatedProps } =
-			prevProps.profile;
-		const prevVerseNumber = prevProps.homepage.match.params.verse;
-		const verseNumber = this.props.homepage.match.params.verse;
-		const audioParam =
-			location?.search &&
-			location.search
-				.slice(1)
-				.split('&')
-				.map((key) => key.split('='))
-				.find((key) => key[0] === 'audio_type');
-		if (
-			audioParam &&
-			(audioParam[1] !== prevProps.homepage.audioType ||
-				audioParam[1] !== this.props.homepage.audioType)
-		) {
-			prevProps.dispatch(setAudioType({ audioType: audioParam[1] }));
-		}
+  componentDidUpdate(prevProps) {
+    // Based on nextProps so that requests have the latest chapter information
+    const {
+      activeTextId,
+      activeBookId,
+      activeChapter,
+      addBookmarkSuccess,
+      audioSource,
+      activeFilesets,
+    } = this.props.homepage;
+    const { userSettings, formattedSource, textData } = this.props;
+    const {
+      userSettings: prevSettings,
+      formattedSource: prevFormattedSource,
+      textData: prevTextData,
+    } = prevProps;
+    const { userId, userAuthenticated } = this.props.profile;
+    const {
+      addBookmarkSuccess: addBookmarkSuccessProps,
+      activeTextId: activeTextIdProps,
+      activeBookId: activeBookIdProps,
+      activeChapter: activeChapterProps,
+      audioSource: prevAudioSource,
+    } = prevProps.homepage;
+    const {
+      userId: userIdProps,
+      userAuthenticated: userAuthenticatedProps,
+    } = prevProps.profile;
+    const prevVerseNumber = prevProps.homepage.match.params.verse;
+    const verseNumber = this.props.homepage.match.params.verse;
+    const audioParam =
+      location?.search &&
+      location.search
+        .slice(1)
+        .split('&')
+        .map((key) => key.split('='))
+        .find((key) => key[0] === 'audio_type');
+    if (
+      audioParam &&
+      (audioParam[1] !== prevProps.homepage.audioType ||
+        audioParam[1] !== this.props.homepage.audioType)
+    ) {
+      prevProps.dispatch(setAudioType({ audioType: audioParam[1] }));
+    }
 
-		if (this.props.homepage.changingVersion) {
-			this.props.dispatch(changeVersion({ state: false }));
-		}
+    if (this.props.homepage.changingVersion) {
+      this.props.dispatch(changeVersion({ state: false }));
+    }
 
-		// If there was a change in the params then make sure loading state is set to false
-		if (
-			prevVerseNumber !== verseNumber ||
-			formattedSource.main !== prevFormattedSource.main ||
-			!isEqual(prevTextData.text, textData.text) ||
-			audioSource !== prevAudioSource ||
-			activeChapter !== activeChapterProps
-		) {
-			this.setTextLoadingState({ state: false });
-			this.getCopyrights({ filesetIds: activeFilesets });
-		}
+    // If there was a change in the params then make sure loading state is set to false
+    if (
+      prevVerseNumber !== verseNumber ||
+      formattedSource.main !== prevFormattedSource.main ||
+      !isEqual(prevTextData.text, textData.text) ||
+      audioSource !== prevAudioSource ||
+      activeChapter !== activeChapterProps
+    ) {
+      this.setTextLoadingState({ state: false });
+      this.getCopyrights({ filesetIds: activeFilesets });
+    }
 
-		// Only apply the them if one of them changed - use the newest one always since that will be what the user clicked
-		if (typeof document !== 'undefined') {
-			if (
-				prevSettings.getIn(['toggleOptions', 'redLetter', 'active']) !==
-				userSettings.getIn(['toggleOptions', 'redLetter', 'active'])
-			) {
-				toggleWordsOfJesus(
-					userSettings.getIn(['toggleOptions', 'redLetter', 'active']),
-				);
-			}
-			if (prevSettings.get('activeTheme') !== userSettings.get('activeTheme')) {
-				applyTheme(userSettings.get('activeTheme'));
-			}
-			if (
-				prevSettings.get('activeFontType') !==
-				userSettings.get('activeFontType')
-			) {
-				applyFontFamily(userSettings.get('activeFontType'));
-			}
-			if (
-				prevSettings.get('activeFontSize') !==
-				userSettings.get('activeFontSize')
-			) {
-				applyFontSize(userSettings.get('activeFontSize'));
-			}
-		}
-		// If there is an authenticated user then send these calls
-		if (
-			userId &&
-			userAuthenticated &&
-			(userId !== userIdProps ||
-				userAuthenticated !== userAuthenticatedProps ||
-				activeTextId !== activeTextIdProps ||
-				activeBookId !== activeBookIdProps ||
-				activeChapter !== activeChapterProps)
-		) {
-			// Should move all of these into the same call to reduce the number of renders in the text component
-			this.props.dispatch(
-				getHighlights({
-					bible: activeTextId,
-					book: activeBookId,
-					chapter: activeChapter,
-					userAuthenticated,
-					userId,
-				}),
-			);
-			this.props.dispatch(
-				getNotes({
-					userId,
-					params: {
-						bible_id: activeTextId,
-						book_id: activeBookId,
-						chapter: activeChapter,
-						limit: 150,
-						page: 1,
-					},
-				}),
-			);
+    // Only apply the them if one of them changed - use the newest one always since that will be what the user clicked
+    if (typeof document !== 'undefined') {
+      if (
+        prevSettings.getIn(['toggleOptions', 'redLetter', 'active']) !==
+        userSettings.getIn(['toggleOptions', 'redLetter', 'active'])
+      ) {
+        toggleWordsOfJesus(
+          userSettings.getIn(['toggleOptions', 'redLetter', 'active']),
+        );
+      }
+      if (prevSettings.get('activeTheme') !== userSettings.get('activeTheme')) {
+        applyTheme(userSettings.get('activeTheme'));
+      }
+      if (
+        prevSettings.get('activeFontType') !==
+        userSettings.get('activeFontType')
+      ) {
+        applyFontFamily(userSettings.get('activeFontType'));
+      }
+      if (
+        prevSettings.get('activeFontSize') !==
+        userSettings.get('activeFontSize')
+      ) {
+        applyFontSize(userSettings.get('activeFontSize'));
+      }
+    }
+    // If there is an authenticated user then send these calls
+    if (
+      userId &&
+      userAuthenticated &&
+      (userId !== userIdProps ||
+        userAuthenticated !== userAuthenticatedProps ||
+        activeTextId !== activeTextIdProps ||
+        activeBookId !== activeBookIdProps ||
+        activeChapter !== activeChapterProps)
+    ) {
+      // Should move all of these into the same call to reduce the number of renders in the text component
+      this.props.dispatch(
+        getHighlights({
+          bible: activeTextId,
+          book: activeBookId,
+          chapter: activeChapter,
+          userAuthenticated,
+          userId,
+        }),
+      );
+      this.props.dispatch(
+        getNotes({
+          userId,
+          params: {
+            bible_id: activeTextId,
+            book_id: activeBookId,
+            chapter: activeChapter,
+            limit: 150,
+            page: 1,
+          },
+        }),
+      );
 
-			this.props.dispatch(
-				getBookmarksForChapter({
-					userId,
-					params: {
-						bible_id: activeTextId,
-						book_id: activeBookId,
-						chapter: activeChapter,
-						limit: 150,
-						page: 1,
-					},
-				}),
-			);
-		}
+      this.props.dispatch(
+        getBookmarksForChapter({
+          userId,
+          params: {
+            bible_id: activeTextId,
+            book_id: activeBookId,
+            chapter: activeChapter,
+            limit: 150,
+            page: 1,
+          },
+        }),
+      );
+    }
 
-		if (addBookmarkSuccess !== addBookmarkSuccessProps && addBookmarkSuccess) {
-			this.props.dispatch(
-				getBookmarksForChapter({
-					userId,
-					params: {
-						bible_id: activeTextId,
-						book_id: activeBookId,
-						chapter: activeChapter,
-						limit: 150,
-						page: 1,
-					},
-				}),
-			);
-			this.props.dispatch(resetBookmarkState());
-		}
+    if (addBookmarkSuccess !== addBookmarkSuccessProps && addBookmarkSuccess) {
+      this.props.dispatch(
+        getBookmarksForChapter({
+          userId,
+          params: {
+            bible_id: activeTextId,
+            book_id: activeBookId,
+            chapter: activeChapter,
+            limit: 150,
+            page: 1,
+          },
+        }),
+      );
+      this.props.dispatch(resetBookmarkState());
+    }
 
-		if (this.props.homepage.firstLoad) {
-			this.toggleFirstLoadForTextSelection();
-		}
+    if (this.props.homepage.firstLoad) {
+      this.toggleFirstLoadForTextSelection();
+    }
 
-		if (!this.props.homepage.firstLoad && prevProps.homepage.firstLoad) {
-			// this.props.dispatch(
-			//   setActiveIsoCode({
-			//     iso: this.props.homepage.initialIsoCode,
-			//     languageCode: this.props.homepage.defaultLanguageCode,
-			//     name: this.props.homepage.initialLanguageName,
-			//   }),
-			// );
+    if (!this.props.homepage.firstLoad && prevProps.homepage.firstLoad) {
+      // this.props.dispatch(
+      //   setActiveIsoCode({
+      //     iso: this.props.homepage.initialIsoCode,
+      //     languageCode: this.props.homepage.defaultLanguageCode,
+      //     name: this.props.homepage.initialLanguageName,
+      //   }),
+      // );
 
-			this.props.dispatch(
-				initApplication({
-					languageIso: this.props.homepage.defaultLanguageIso,
-					languageCode: this.props.homepage.defaultLanguageCode,
-				}),
-			);
-		}
-	}
+      this.props.dispatch(
+        initApplication({
+          languageIso: this.props.homepage.defaultLanguageIso,
+          languageCode: this.props.homepage.defaultLanguageCode,
+        }),
+      );
+    }
+  }
 
-	componentWillUnmount() {
-		clearTimeout(this.timer);
-	}
+  componentWillUnmount() {
+    clearTimeout(this.timer);
+  }
 
-	getCopyrights = (props) => this.props.dispatch(getCopyrights(props));
+  getCopyrights = (props) => this.props.dispatch(getCopyrights(props));
 
-	setTextLoadingState = (props) =>
-		this.props.dispatch(setChapterTextLoadingState(props));
+  setTextLoadingState = (props) =>
+    this.props.dispatch(setChapterTextLoadingState(props));
 
-	checkForVideo = async (filesetId, bookId, chapter) => {
-		if (!filesetId) {
-			this.props.dispatch(
-				setHasVideo({
-					state: false,
-					videoChapterState: false,
-					videoPlayerOpen: false,
-				}),
-			);
-			return;
-		}
-		const hasVideo = await checkForVideoAsync(filesetId, bookId, chapter);
+  checkForVideo = async (filesetId, bookId, chapter) => {
+    if (!filesetId) {
+      this.props.dispatch(
+        setHasVideo({
+          state: false,
+          videoChapterState: false,
+          videoPlayerOpen: false,
+        }),
+      );
+      return;
+    }
+    const hasVideo = await checkForVideoAsync(filesetId, bookId, chapter);
 
-		this.props.dispatch(
-			setHasVideo({
-				state: hasVideo,
-				videoChapterState: hasVideo,
-				videoPlayerOpen: hasVideo,
-			}),
-		);
-	};
+    this.props.dispatch(
+      setHasVideo({
+        state: hasVideo,
+        videoChapterState: hasVideo,
+        videoPlayerOpen: hasVideo,
+      }),
+    );
+  };
 
-	toggleFirstLoadForTextSelection = () =>
-		this.props.homepage.firstLoad &&
-		this.props.dispatch(toggleFirstLoadForTextSelection());
+  toggleFirstLoadForTextSelection = () =>
+    this.props.homepage.firstLoad &&
+    this.props.dispatch(toggleFirstLoadForTextSelection());
 
-	toggleProfile = () => {
-		this.props.dispatch(toggleProfile());
-	};
+  toggleProfile = () => {
+    this.props.dispatch(toggleProfile());
+  };
 
-	toggleNotesModal = () => {
-		this.props.dispatch(toggleNotesModal());
-	};
+  toggleNotesModal = () => {
+    this.props.dispatch(toggleNotesModal());
+  };
 
-	toggleSettingsModal = () => {
-		this.props.dispatch(toggleSettingsModal());
-	};
+  toggleSettingsModal = () => {
+    this.props.dispatch(toggleSettingsModal());
+  };
 
-	toggleSearchModal = () => {
-		this.props.dispatch(toggleSearchModal());
-	};
+  toggleSearchModal = () => {
+    this.props.dispatch(toggleSearchModal());
+  };
 
-	toggleChapterSelection = () => {
-		this.props.dispatch(toggleChapterSelection());
-	};
+  toggleChapterSelection = () => {
+    this.props.dispatch(toggleChapterSelection());
+  };
 
-	toggleVersionSelection = () => {
-		this.props.dispatch(toggleVersionSelection());
-	};
+  toggleVersionSelection = () => {
+    this.props.dispatch(toggleVersionSelection());
+  };
 
-	render() {
-		const {
-			activeBookId,
-			activeTextId,
-			activeChapter,
-			activeBookName,
-			activeFilesets,
-			activeTextName,
-			activeFilesetId,
-			audioPlayerState,
-			books,
-			isProfileActive,
-			isNotesModalActive,
-			isSearchModalActive,
-			isSettingsModalActive,
-			isVersionSelectionActive,
-			isChapterSelectionActive,
-			userAgent,
-			loadingAudio,
-			loadingNewChapterText,
-			chapterTextLoadingState,
-			changingVersion,
-			videoPlayerOpen,
-			hasVideo,
-			audioType,
-			textDirection,
-		} = this.props.homepage;
+  render() {
+    const {
+      activeBookId,
+      activeTextId,
+      activeChapter,
+      activeBookName,
+      activeFilesets,
+      activeTextName,
+      activeFilesetId,
+      audioPlayerState,
+      books,
+      isProfileActive,
+      isNotesModalActive,
+      isSearchModalActive,
+      isSettingsModalActive,
+      isVersionSelectionActive,
+      isChapterSelectionActive,
+      userAgent,
+      loadingAudio,
+      loadingNewChapterText,
+      chapterTextLoadingState,
+      changingVersion,
+      videoPlayerOpen,
+      hasVideo,
+      audioType,
+      textDirection,
+    } = this.props.homepage;
 
-		const { userSettings, isMenuOpen, isIe, activeNotesView } = this.props;
+    const { userSettings, isMenuOpen, isIe, activeNotesView } = this.props;
 
-		const { isScrollingDown } = this.state;
-		const { text: updatedText } = this.props.textData;
-		const token = this.props.homepage.match.params.token || '';
-		const verse = this.props.homepage.match.params.verse || '';
+    const { isScrollingDown } = this.state;
+    const { text: updatedText } = this.props.textData;
+    const token = this.props.homepage.match.params.token || '';
+    const verse = this.props.homepage.match.params.verse || '';
 
-		return (
-			<>
-				<NavigationBar
-					userAgent={userAgent}
-					activeTextId={activeTextId}
-					activeChapter={activeChapter}
-					activeTextName={activeTextName}
-					activeBookName={activeBookName}
-					textDirection={textDirection}
-					theme={userSettings.get('activeTheme')}
-					isScrollingDown={isScrollingDown}
-					isChapterSelectionActive={isChapterSelectionActive}
-					isVersionSelectionActive={isVersionSelectionActive}
-					toggleChapterSelection={this.toggleChapterSelection}
-					toggleVersionSelection={this.toggleVersionSelection}
-				/>
-				<div
-					className={
-						videoPlayerOpen || !audioPlayerState
-							? 'content-container audio-closed'
-							: 'content-container'
-					}
-				>
-					{activeTextId && (
-						<VideoPlayer
-							fileset={
-								activeFilesets.filter((f) => f.type === 'video_stream')[0]
-							}
-							bookId={activeBookId}
-							chapter={activeChapter}
-							books={books}
-							text={updatedText}
-							textId={activeTextId}
-						/>
-					)}
-					{activeTextId && (
-						<Text
-							books={books}
-							text={updatedText}
-							hasVideo={hasVideo}
-							verseNumber={verse}
-							audioType={audioType}
-							menuIsOpen={isMenuOpen}
-							activeTextId={activeTextId}
-							activeBookId={activeBookId}
-							loadingAudio={loadingAudio}
-							activeChapter={activeChapter}
-							changingVersion={changingVersion}
-							videoPlayerOpen={videoPlayerOpen}
-							isScrollingDown={isScrollingDown}
-							audioPlayerState={audioPlayerState}
-							loadingNewChapterText={loadingNewChapterText}
-							chapterTextLoadingState={chapterTextLoadingState}
-						/>
-					)}
-				</div>
-				<TransitionGroup>
-					{isSettingsModalActive ? (
-						<FadeTransition
-							classNames="slide-from-right"
-							in={isSettingsModalActive}
-						>
-							<Settings
-								userSettings={userSettings}
-								toggleSettingsModal={this.toggleSettingsModal}
-								isIe={isIe}
-							/>
-						</FadeTransition>
-					) : null}
-					{isProfileActive ? (
-						<FadeTransition classNames="slide-from-left" in={isProfileActive}>
-							<Profile
-								resetPasswordSent={this.resetPasswordSent}
-								userAccessToken={token}
-								toggleProfile={this.toggleProfile}
-								isIe={isIe}
-							/>
-						</FadeTransition>
-					) : null}
-					{isNotesModalActive ? (
-						<FadeTransition
-							classNames="slide-from-right"
-							in={isNotesModalActive}
-						>
-							<Notes
-								activeBookId={activeBookId}
-								activeChapter={activeChapter}
-								toggleProfile={this.toggleProfile}
-								toggleNotesModal={this.toggleNotesModal}
-								openView={activeNotesView}
-								isIe={isIe}
-							/>
-						</FadeTransition>
-					) : null}
-					{isSearchModalActive ? (
-						<FadeTransition
-							classNames="slide-from-left"
-							in={isSearchModalActive}
-						>
-							<SearchContainer
-								bibleId={activeTextId}
-								activeFilesetId={activeFilesetId}
-								books={books}
-								toggleSearchModal={this.toggleSearchModal}
-								isIe={isIe}
-							/>
-						</FadeTransition>
-					) : null}
-				</TransitionGroup>
-				{activeTextId && (
-					<AudioPlayer verseNumber={verse} audioType={audioType} />
-				)}
-				<Footer
-					profileActive={isProfileActive}
-					searchActive={isSearchModalActive}
-					notebookActive={isNotesModalActive}
-					settingsActive={isSettingsModalActive}
-					isScrollingDown={isScrollingDown}
-					toggleProfile={this.toggleProfile}
-					toggleSearch={this.toggleSearchModal}
-					toggleNotebook={this.toggleNotesModal}
-					toggleSettingsModal={this.toggleSettingsModal}
-				/>
-			</>
-		);
-	}
+    return (
+      <>
+        <NavigationBar
+          userAgent={userAgent}
+          activeTextId={activeTextId}
+          activeChapter={activeChapter}
+          activeTextName={activeTextName}
+          activeBookName={activeBookName}
+          textDirection={textDirection}
+          theme={userSettings.get('activeTheme')}
+          isScrollingDown={isScrollingDown}
+          isChapterSelectionActive={isChapterSelectionActive}
+          isVersionSelectionActive={isVersionSelectionActive}
+          toggleChapterSelection={this.toggleChapterSelection}
+          toggleVersionSelection={this.toggleVersionSelection}
+        />
+        <div
+          className={
+            videoPlayerOpen || !audioPlayerState
+              ? 'content-container audio-closed'
+              : 'content-container'
+          }
+        >
+          {(activeTextId && (
+              <VideoPlayer
+                fileset={
+                  activeFilesets.filter((f) => f.type === 'video_stream')[0]
+                }
+                bookId={activeBookId}
+                chapter={activeChapter}
+                books={books}
+                text={updatedText}
+                textId={activeTextId}
+              />
+            )
+          )}
+          { activeTextId && (
+              <Text
+              books={books}
+              text={updatedText}
+              hasVideo={hasVideo}
+              verseNumber={verse}
+              audioType={audioType}
+              menuIsOpen={isMenuOpen}
+              activeTextId={activeTextId}
+              activeBookId={activeBookId}
+              loadingAudio={loadingAudio}
+              activeChapter={activeChapter}
+              changingVersion={changingVersion}
+              videoPlayerOpen={videoPlayerOpen}
+              isScrollingDown={isScrollingDown}
+              audioPlayerState={audioPlayerState}
+              loadingNewChapterText={loadingNewChapterText}
+              chapterTextLoadingState={chapterTextLoadingState}
+              />
+          )}
+        </div>
+        <TransitionGroup>
+          {isSettingsModalActive ? (
+            <FadeTransition
+              classNames="slide-from-right"
+              in={isSettingsModalActive}
+            >
+              <Settings
+                userSettings={userSettings}
+                toggleSettingsModal={this.toggleSettingsModal}
+                isIe={isIe}
+              />
+            </FadeTransition>
+          ) : null}
+          {isProfileActive ? (
+            <FadeTransition classNames="slide-from-left" in={isProfileActive}>
+              <Profile
+                resetPasswordSent={this.resetPasswordSent}
+                userAccessToken={token}
+                toggleProfile={this.toggleProfile}
+                isIe={isIe}
+              />
+            </FadeTransition>
+          ) : null}
+          {isNotesModalActive ? (
+            <FadeTransition
+              classNames="slide-from-right"
+              in={isNotesModalActive}
+            >
+              <Notes
+                activeBookId={activeBookId}
+                activeChapter={activeChapter}
+                toggleProfile={this.toggleProfile}
+                toggleNotesModal={this.toggleNotesModal}
+                openView={activeNotesView}
+                isIe={isIe}
+              />
+            </FadeTransition>
+          ) : null}
+          {isSearchModalActive ? (
+            <FadeTransition
+              classNames="slide-from-left"
+              in={isSearchModalActive}
+            >
+              <SearchContainer
+                bibleId={activeTextId}
+                activeFilesetId={activeFilesetId}
+                books={books}
+                toggleSearchModal={this.toggleSearchModal}
+                isIe={isIe}
+              />
+            </FadeTransition>
+          ) : null}
+        </TransitionGroup>
+        {activeTextId && <AudioPlayer verseNumber={verse} audioType={audioType} />}
+        <Footer
+          profileActive={isProfileActive}
+          searchActive={isSearchModalActive}
+          notebookActive={isNotesModalActive}
+          settingsActive={isSettingsModalActive}
+          isScrollingDown={isScrollingDown}
+          toggleProfile={this.toggleProfile}
+          toggleSearch={this.toggleSearchModal}
+          toggleNotebook={this.toggleNotesModal}
+          toggleSettingsModal={this.toggleSettingsModal}
+        />
+      </>
+    );
+  }
 }
 
 HomePage.propTypes = {
-	dispatch: PropTypes.func.isRequired,
-	homepage: PropTypes.shape({
-		activeBookId: PropTypes.string,
-		activeTextId: PropTypes.string.isRequired,
-		activeChapter: PropTypes.number,
-		activeBookName: PropTypes.string,
-		activeFilesets: PropTypes.array,
-		activeTextName: PropTypes.string,
-		activeFilesetId: PropTypes.string,
-		audioPlayerState: PropTypes.bool,
-		books: PropTypes.array,
-		isProfileActive: PropTypes.bool,
-		isNotesModalActive: PropTypes.bool,
-		isSearchModalActive: PropTypes.bool,
-		isSettingsModalActive: PropTypes.bool,
-		isVersionSelectionActive: PropTypes.bool,
-		isChapterSelectionActive: PropTypes.bool,
-		userAgent: PropTypes.string,
-		loadingAudio: PropTypes.bool,
-		loadingNewChapterText: PropTypes.bool,
-		chapterTextLoadingState: PropTypes.bool,
-		changingVersion: PropTypes.bool,
-		videoPlayerOpen: PropTypes.bool,
-		hasVideo: PropTypes.bool,
-		audioType: PropTypes.string,
-		textDirection: PropTypes.string,
-		match: PropTypes.object,
-		firstLoad: PropTypes.bool,
-		addBookmarkSuccess: PropTypes.bool,
-		defaultLanguageIso: PropTypes.string,
-		defaultLanguageCode: PropTypes.number,
-		audioSource: PropTypes.string,
-	}).isRequired,
-	userSettings: PropTypes.object,
-	formattedSource: PropTypes.object,
-	userAuthenticated: PropTypes.bool,
-	isIe: PropTypes.bool,
-	activeNotesView: PropTypes.string,
-	userId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-	textData: PropTypes.object,
-	isMenuOpen: PropTypes.bool,
-	profile: PropTypes.object,
+  dispatch: PropTypes.func.isRequired,
+  homepage: PropTypes.shape({
+    activeBookId: PropTypes.string,
+    activeTextId: PropTypes.string.isRequired,
+    activeChapter: PropTypes.number,
+    activeBookName: PropTypes.string,
+    activeFilesets: PropTypes.array,
+    activeTextName: PropTypes.string,
+    activeFilesetId: PropTypes.string,
+    audioPlayerState: PropTypes.bool,
+    books: PropTypes.array,
+    isProfileActive: PropTypes.bool,
+    isNotesModalActive: PropTypes.bool,
+    isSearchModalActive: PropTypes.bool,
+    isSettingsModalActive: PropTypes.bool,
+    isVersionSelectionActive: PropTypes.bool,
+    isChapterSelectionActive: PropTypes.bool,
+    userAgent: PropTypes.string,
+    loadingAudio: PropTypes.bool,
+    loadingNewChapterText: PropTypes.bool,
+    chapterTextLoadingState: PropTypes.bool,
+    changingVersion: PropTypes.bool,
+    videoPlayerOpen: PropTypes.bool,
+    hasVideo: PropTypes.bool,
+    audioType: PropTypes.string,
+    textDirection: PropTypes.string,
+    match: PropTypes.object,
+    firstLoad: PropTypes.bool,
+    addBookmarkSuccess: PropTypes.bool,
+    defaultLanguageIso: PropTypes.string,
+    defaultLanguageCode: PropTypes.number,
+    audioSource: PropTypes.string,
+  }).isRequired,
+  userSettings: PropTypes.object,
+  formattedSource: PropTypes.object,
+  userAuthenticated: PropTypes.bool,
+  isIe: PropTypes.bool,
+  activeNotesView: PropTypes.string,
+  userId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  textData: PropTypes.object,
+  isMenuOpen: PropTypes.bool,
+  profile: PropTypes.object,
 };
 
 const mapStateToProps = createStructuredSelector({
-	homepage: makeSelectHomePage(),
-	formattedSource: selectFormattedSource(),
-	userAuthenticated: selectAuthenticationStatus(),
-	userId: selectUserId(),
-	textData: selectUserNotes(),
-	profile: makeSelectProfile(),
-	isMenuOpen: selectMenuOpenState(),
-	userSettings: selectSettings(),
-	activeNotesView: selectActiveNotesView(),
+  homepage: makeSelectHomePage(),
+  formattedSource: selectFormattedSource(),
+  userAuthenticated: selectAuthenticationStatus(),
+  userId: selectUserId(),
+  textData: selectUserNotes(),
+  profile: makeSelectProfile(),
+  isMenuOpen: selectMenuOpenState(),
+  userSettings: selectSettings(),
+  activeNotesView: selectActiveNotesView(),
 });
 
 function mapDispatchToProps(dispatch) {
-	return {
-		dispatch,
-	};
+  return {
+    dispatch,
+  };
 }
 
-const withConnect = connect(mapStateToProps, mapDispatchToProps);
+const withConnect = connect(
+  mapStateToProps,
+  mapDispatchToProps,
+);
 
 // Defeats the purpose of code splitting - need to figure out a different method to reduce bundle size
 const withReducer = injectReducer({ key: 'homepage', reducer });
 const withSaga = injectSaga({ key: 'homepage', saga });
 const withTextReducer = injectReducer({
-	key: 'textSelection',
-	reducer: textReducer,
+  key: 'textSelection',
+  reducer: textReducer,
 });
 const withTextSaga = injectSaga({ key: 'textSelection', saga: textSaga });
 const withNotesSaga = injectSaga({ key: 'notes', saga: notesSaga });
 const withNotesReducer = injectReducer({ key: 'notes', reducer: notesReducer });
 const withProfileReducer = injectReducer({
-	key: 'profile',
-	reducer: profileReducer,
+  key: 'profile',
+  reducer: profileReducer,
 });
 const withProfileSaga = injectSaga({ key: 'profile', saga: profileSaga });
 const withSettingsReducer = injectReducer({
-	key: 'settings',
-	reducer: settingsReducer,
+  key: 'settings',
+  reducer: settingsReducer,
 });
 
 export default compose(
-	withReducer,
-	withTextReducer,
-	withProfileReducer,
-	withProfileSaga,
-	withNotesReducer,
-	withSaga,
-	withNotesSaga,
-	withTextSaga,
-	withSettingsReducer,
-	withConnect,
+  withReducer,
+  withTextReducer,
+  withProfileReducer,
+  withProfileSaga,
+  withNotesReducer,
+  withSaga,
+  withNotesSaga,
+  withTextSaga,
+  withSettingsReducer,
+  withConnect,
 )(HomePage);

--- a/app/containers/HomePage/reducer.js
+++ b/app/containers/HomePage/reducer.js
@@ -202,10 +202,7 @@ function homePageReducer(state = initialState, action = { type: null }) {
 				!state.get('isVersionSelectionActive'),
 			);
 		case CLOSE_VERSION_SELECTION:
-			return state.set(
-				'isVersionSelectionActive',
-				false,
-			);
+			return state.set('isVersionSelectionActive', false);
 		case TOGGLE_INFORMATION_MODAL:
 			return state.set(
 				'isInformationModalActive',
@@ -219,7 +216,6 @@ function homePageReducer(state = initialState, action = { type: null }) {
 			return state.set('activeChapter', action.chapter);
 		case ACTIVE_TEXT_ID:
 			return state
-				.set('activeFilesets', fromJS(action.filesets))
 				.set('activeTextName', action.textName)
 				.setIn(['userSettings', 'autoPlayEnabled'], false)
 				.set('activeTextId', action.textId);

--- a/app/utils/getNextChapterUrl.js
+++ b/app/utils/getNextChapterUrl.js
@@ -1,114 +1,114 @@
 import url from './hrefLinkOrAsLink';
 
 export default ({
-	books,
-	chapter,
-	bookId,
-	textId,
-	verseNumber,
-	text: chapterText,
-	isHref,
-	audioType,
+  books,
+  chapter,
+  bookId,
+  textId,
+  verseNumber,
+  text: chapterText,
+  isHref,
+  audioType,
 }) => {
-	if (!books || !books.length) {
-		return url({ audioType, textId, bookId, chapter, isHref });
-	}
-	if (verseNumber && chapterText.length) {
-		const nextVerse = parseInt(verseNumber, 10) + 1 || 1;
-		const lastVerse = chapterText.length;
+  if (!books || !books.length) {
+    return url({ audioType, textId, bookId, chapter, isHref });
+  }
+  if (verseNumber && chapterText.length) {
+    const nextVerse = parseInt(verseNumber, 10) + 1 || 1;
+    const lastVerse = chapterText.length;
 
-		// Handles the verses
-		if (nextVerse <= lastVerse && nextVerse > 0) {
-			// The next verse is within a valid range
-			return url({ audioType, textId, bookId, chapter, nextVerse, isHref });
-		} else if (nextVerse < 0) {
-			// The next verse is below 0 and thus invalid
-			return url({
-				audioType,
-				textId,
-				bookId,
-				chapter,
-				nextVerse: '1',
-				isHref,
-			});
-		} else if (nextVerse > lastVerse) {
-			// Next verse is above the last verse in the chapter and thus is invalid
-			return url({
-				audioType,
-				textId,
-				bookId,
-				chapter,
-				nextVerse: lastVerse,
-				isHref,
-			});
-		}
-	} else if (verseNumber) {
-		const nextVerse = parseInt(verseNumber, 10) + 1 || 1;
+    // Handles the verses
+    if (nextVerse <= lastVerse && nextVerse > 0) {
+      // The next verse is within a valid range
+      return url({ audioType, textId, bookId, chapter, nextVerse, isHref });
+    } else if (nextVerse < 0) {
+      // The next verse is below 0 and thus invalid
+      return url({
+        audioType,
+        textId,
+        bookId,
+        chapter,
+        nextVerse: '1',
+        isHref,
+      });
+    } else if (nextVerse > lastVerse) {
+      // Next verse is above the last verse in the chapter and thus is invalid
+      return url({
+        audioType,
+        textId,
+        bookId,
+        chapter,
+        nextVerse: lastVerse,
+        isHref,
+      });
+    }
+  } else if (verseNumber) {
+    const nextVerse = parseInt(verseNumber, 10) + 1 || 1;
 
-		if (nextVerse && nextVerse > 0) {
-			// The next verse is within a valid range
-			return url({ audioType, textId, bookId, chapter, nextVerse, isHref });
-		} else if (nextVerse < 0) {
-			// The next verse is below 0 and thus invalid
+    if (nextVerse && nextVerse > 0) {
+      // The next verse is within a valid range
+      return url({ audioType, textId, bookId, chapter, nextVerse, isHref });
+    } else if (nextVerse < 0) {
+      // The next verse is below 0 and thus invalid
 
-			return url({
-				audioType,
-				textId,
-				bookId,
-				chapter,
-				nextVerse: '1',
-				isHref,
-			});
-			// Need to find a way to do this for formatted text
-			// Next verse is above the last verse in the chapter and thus is invalid
-		}
-	}
+      return url({
+        audioType,
+        textId,
+        bookId,
+        chapter,
+        nextVerse: '1',
+        isHref,
+      });
+      // Need to find a way to do this for formatted text
+      // Next verse is above the last verse in the chapter and thus is invalid
+    }
+  }
 
-	// Handles the chapters
-	const activeBook = books.find(
-		(book) => book.book_id.toLowerCase() === bookId.toLowerCase(),
-	);
-	// This relies on the books list already being sorted in ascending book_order
-	const nextBook = books.find(
-		(book) =>
-			activeBook &&
-			(book.book_order === activeBook.book_order + 1 ||
-				book.book_order > activeBook.book_order),
-	);
-	const maxChapter = activeBook?.chapters[activeBook.chapters.length - 1];
-	// If the next book in line doesn't exist and we are already at the last chapter just return
-	if (!nextBook && chapter === maxChapter) {
-		return url({ audioType, textId, bookId, chapter });
-	}
+  // Handles the chapters
+  const activeBook = books.find(
+    (book) => book.book_id.toLowerCase() === bookId.toLowerCase(),
+  );
+  // This relies on the books list already being sorted in ascending book_order
+  const nextBook = books.find(
+    (book) =>
+      activeBook &&
+      (book.book_order === activeBook.book_order + 1 ||
+        book.book_order > activeBook.book_order),
+  );
+  const maxChapter = activeBook?.chapters[activeBook.chapters.length - 1];
+  // If the next book in line doesn't exist and we are already at the last chapter just return
+  if (!nextBook && chapter === maxChapter) {
+    return url({ audioType, textId, bookId, chapter });
+  }
 
-	if (chapter === maxChapter) {
-		// Need to get the first chapter of the next book
-		return url({
-			audioType,
-			textId,
-			bookId: nextBook.book_id,
-			chapter: nextBook.chapters[0],
-			isHref,
-		});
-	}
+  if (chapter === maxChapter) {
+    // Need to get the first chapter of the next book
+    return url({
+      audioType,
+      textId,
+      bookId: nextBook.book_id,
+      chapter: nextBook.chapters[0],
+      isHref,
+    });
+  }
 
-	const chapterIndex = activeBook?.chapters.findIndex(
-		(c) => c === chapter || c > chapter,
-	);
-	const nextChapterNumber =
-		activeBook?.chapters[chapterIndex] === chapter
-			? activeBook?.chapters[chapterIndex + 1]
-			: activeBook?.chapters[chapterIndex];
+  const chapterIndex = activeBook?.chapters.findIndex(
+    (c) => c === chapter || c > chapter,
+  );
+  const nextChapterNumber =
+    activeBook?.chapters[chapterIndex] === chapter
+      ? activeBook?.chapters[chapterIndex + 1]
+      : activeBook?.chapters[chapterIndex];
 
-	if (!nextChapterNumber) {
-		return url({ audioType, textId, bookId, chapter, isHref });
-	}
+  if (!nextChapterNumber) {
+    return url({ audioType, textId, bookId, chapter, isHref });
+  }
 
-	return url({
-		audioType,
-		textId,
-		bookId,
-		chapter: nextChapterNumber,
-		isHref,
-	});
+  return url({
+    audioType,
+    textId,
+    bookId,
+    chapter: nextChapterNumber,
+    isHref,
+  });
 };

--- a/app/utils/getNextChapterUrl.js
+++ b/app/utils/getNextChapterUrl.js
@@ -1,109 +1,114 @@
 import url from './hrefLinkOrAsLink';
 
 export default ({
-  books,
-  chapter,
-  bookId,
-  textId,
-  verseNumber,
-  text: chapterText,
-  isHref,
-  audioType,
+	books,
+	chapter,
+	bookId,
+	textId,
+	verseNumber,
+	text: chapterText,
+	isHref,
+	audioType,
 }) => {
-  if (!books || !books.length) {
-    return url({ audioType, textId, bookId, chapter, isHref });
-  }
-  if (verseNumber && chapterText.length) {
-    const nextVerse = parseInt(verseNumber, 10) + 1 || 1;
-    const lastVerse = chapterText.length;
+	if (!books || !books.length) {
+		return url({ audioType, textId, bookId, chapter, isHref });
+	}
+	if (verseNumber && chapterText.length) {
+		const nextVerse = parseInt(verseNumber, 10) + 1 || 1;
+		const lastVerse = chapterText.length;
 
-    // Handles the verses
-    if (nextVerse <= lastVerse && nextVerse > 0) {
-      // The next verse is within a valid range
-      return url({ audioType, textId, bookId, chapter, nextVerse, isHref });
-    } else if (nextVerse < 0) {
-      // The next verse is below 0 and thus invalid
-      return url({
-        audioType,
-        textId,
-        bookId,
-        chapter,
-        nextVerse: '1',
-        isHref,
-      });
-    } else if (nextVerse > lastVerse) {
-      // Next verse is above the last verse in the chapter and thus is invalid
-      return url({
-        audioType,
-        textId,
-        bookId,
-        chapter,
-        nextVerse: lastVerse,
-        isHref,
-      });
-    }
-  } else if (verseNumber) {
-    const nextVerse = parseInt(verseNumber, 10) + 1 || 1;
+		// Handles the verses
+		if (nextVerse <= lastVerse && nextVerse > 0) {
+			// The next verse is within a valid range
+			return url({ audioType, textId, bookId, chapter, nextVerse, isHref });
+		} else if (nextVerse < 0) {
+			// The next verse is below 0 and thus invalid
+			return url({
+				audioType,
+				textId,
+				bookId,
+				chapter,
+				nextVerse: '1',
+				isHref,
+			});
+		} else if (nextVerse > lastVerse) {
+			// Next verse is above the last verse in the chapter and thus is invalid
+			return url({
+				audioType,
+				textId,
+				bookId,
+				chapter,
+				nextVerse: lastVerse,
+				isHref,
+			});
+		}
+	} else if (verseNumber) {
+		const nextVerse = parseInt(verseNumber, 10) + 1 || 1;
 
-    if (nextVerse && nextVerse > 0) {
-      // The next verse is within a valid range
-      return url({ audioType, textId, bookId, chapter, nextVerse, isHref });
-    } else if (nextVerse < 0) {
-      // The next verse is below 0 and thus invalid
+		if (nextVerse && nextVerse > 0) {
+			// The next verse is within a valid range
+			return url({ audioType, textId, bookId, chapter, nextVerse, isHref });
+		} else if (nextVerse < 0) {
+			// The next verse is below 0 and thus invalid
 
-      return url({
-        audioType,
-        textId,
-        bookId,
-        chapter,
-        nextVerse: '1',
-        isHref,
-      });
-      // Need to find a way to do this for formatted text
-      // Next verse is above the last verse in the chapter and thus is invalid
-    }
-  }
+			return url({
+				audioType,
+				textId,
+				bookId,
+				chapter,
+				nextVerse: '1',
+				isHref,
+			});
+			// Need to find a way to do this for formatted text
+			// Next verse is above the last verse in the chapter and thus is invalid
+		}
+	}
 
-  // Handles the chapters
-  const activeBook = books.find(
-    (book) => book.book_id.toLowerCase() === bookId.toLowerCase(),
-  );
-  // This relies on the books list already being sorted in ascending book_order
-  const nextBook = books.find(
-    (book) =>
-      book.book_order === activeBook.book_order + 1 ||
-      book.book_order > activeBook.book_order,
-  );
-  const maxChapter = activeBook.chapters[activeBook.chapters.length - 1];
-  // If the next book in line doesn't exist and we are already at the last chapter just return
-  if (!nextBook && chapter === maxChapter) {
-    return url({ audioType, textId, bookId, chapter });
-  }
+	// Handles the chapters
+	const activeBook = books.find(
+		(book) => book.book_id.toLowerCase() === bookId.toLowerCase(),
+	);
+	// This relies on the books list already being sorted in ascending book_order
+	const nextBook = books.find(
+		(book) =>
+			activeBook &&
+			(book.book_order === activeBook.book_order + 1 ||
+				book.book_order > activeBook.book_order),
+	);
+	const maxChapter = activeBook?.chapters[activeBook.chapters.length - 1];
+	// If the next book in line doesn't exist and we are already at the last chapter just return
+	if (!nextBook && chapter === maxChapter) {
+		return url({ audioType, textId, bookId, chapter });
+	}
 
-  if (chapter === maxChapter) {
-    // Need to get the first chapter of the next book
-    return url({
-      audioType,
-      textId,
-      bookId: nextBook.book_id,
-      chapter: nextBook.chapters[0],
-      isHref,
-    });
-  }
+	if (chapter === maxChapter) {
+		// Need to get the first chapter of the next book
+		return url({
+			audioType,
+			textId,
+			bookId: nextBook.book_id,
+			chapter: nextBook.chapters[0],
+			isHref,
+		});
+	}
 
-  const chapterIndex = activeBook.chapters.findIndex(
-    (c) => c === chapter || c > chapter,
-  );
-  const nextChapterNumber =
-    activeBook.chapters[chapterIndex] === chapter
-      ? activeBook.chapters[chapterIndex + 1]
-      : activeBook.chapters[chapterIndex];
+	const chapterIndex = activeBook?.chapters.findIndex(
+		(c) => c === chapter || c > chapter,
+	);
+	const nextChapterNumber =
+		activeBook?.chapters[chapterIndex] === chapter
+			? activeBook?.chapters[chapterIndex + 1]
+			: activeBook?.chapters[chapterIndex];
 
-  return url({
-    audioType,
-    textId,
-    bookId,
-    chapter: nextChapterNumber,
-    isHref,
-  });
+	if (!nextChapterNumber) {
+		return url({ audioType, textId, bookId, chapter, isHref });
+	}
+
+	return url({
+		audioType,
+		textId,
+		bookId,
+		chapter: nextChapterNumber,
+		isHref,
+	});
 };

--- a/app/utils/getPreviousChapterUrl.js
+++ b/app/utils/getPreviousChapterUrl.js
@@ -2,119 +2,123 @@ import { fromJS } from 'immutable';
 import url from './hrefLinkOrAsLink';
 
 export default ({
-  books,
-  chapter,
-  bookId,
-  textId,
-  verseNumber,
-  text: chapterText,
-  isHref,
-  audioType,
+	books,
+	chapter,
+	bookId,
+	textId,
+	verseNumber,
+	text: chapterText,
+	isHref,
+	audioType,
 }) => {
-  if (!books || !books.length) {
-    return url({ audioType, textId, bookId, chapter, isHref });
-  }
-  if (verseNumber && chapterText.length) {
-    const prevVerse = parseInt(verseNumber, 10) - 1 || 1;
-    const lastVerse = chapterText.length;
-    // Is it past the max verses for the chapter?
-    // if not increment it by 1
-    if (prevVerse <= lastVerse && prevVerse > 0) {
-      // Verse was valid
+	if (!books || !books.length) {
+		return url({ audioType, textId, bookId, chapter, isHref });
+	}
+	if (verseNumber && chapterText.length) {
+		const prevVerse = parseInt(verseNumber, 10) - 1 || 1;
+		const lastVerse = chapterText.length;
+		// Is it past the max verses for the chapter?
+		// if not increment it by 1
+		if (prevVerse <= lastVerse && prevVerse > 0) {
+			// Verse was valid
 
-      return url({
-        audioType,
-        textId,
-        bookId,
-        chapter,
-        nextVerse: prevVerse,
-        isHref,
-      });
-    } else if (prevVerse < 0) {
-      // Verse was below valid range
+			return url({
+				audioType,
+				textId,
+				bookId,
+				chapter,
+				nextVerse: prevVerse,
+				isHref,
+			});
+		} else if (prevVerse < 0) {
+			// Verse was below valid range
 
-      return url({
-        audioType,
-        textId,
-        bookId,
-        chapter,
-        nextVerse: '1',
-        isHref,
-      });
-    } else if (prevVerse > lastVerse) {
-      // Verse was above valid range
+			return url({
+				audioType,
+				textId,
+				bookId,
+				chapter,
+				nextVerse: '1',
+				isHref,
+			});
+		} else if (prevVerse > lastVerse) {
+			// Verse was above valid range
 
-      return url({
-        audioType,
-        textId,
-        bookId,
-        chapter,
-        nextVerse: lastVerse,
-        isHref,
-      });
-    }
-  } else if (verseNumber) {
-    const nextVerse = parseInt(verseNumber, 10) - 1 || 1;
+			return url({
+				audioType,
+				textId,
+				bookId,
+				chapter,
+				nextVerse: lastVerse,
+				isHref,
+			});
+		}
+	} else if (verseNumber) {
+		const nextVerse = parseInt(verseNumber, 10) - 1 || 1;
 
-    if (nextVerse && nextVerse > 0) {
-      // The next verse is within a valid range
+		if (nextVerse && nextVerse > 0) {
+			// The next verse is within a valid range
 
-      return url({ audioType, textId, bookId, chapter, nextVerse, isHref });
-    } else if (nextVerse < 0) {
-      // The next verse is below 0 and thus invalid
+			return url({ audioType, textId, bookId, chapter, nextVerse, isHref });
+		} else if (nextVerse < 0) {
+			// The next verse is below 0 and thus invalid
 
-      return url({
-        audioType,
-        textId,
-        bookId,
-        chapter,
-        nextVerse: '1',
-        isHref,
-      });
-    }
-  }
+			return url({
+				audioType,
+				textId,
+				bookId,
+				chapter,
+				nextVerse: '1',
+				isHref,
+			});
+		}
+	}
 
-  if (
-    books[0] &&
-    bookId.toLowerCase() === books[0].book_id.toLowerCase() &&
-    chapter - 1 === 0
-  ) {
-    return url({ audioType, textId, bookId, chapter, isHref });
-  }
+	if (
+		books[0] &&
+		bookId.toLowerCase() === books[0].book_id.toLowerCase() &&
+		chapter - 1 === 0
+	) {
+		return url({ audioType, textId, bookId, chapter, isHref });
+	}
 
-  let activeBookIndex;
-  let previousBookIndex;
+	let activeBookIndex;
+	let previousBookIndex;
 
-  books.forEach((book, index) => {
-    if (book.book_id.toLowerCase() === bookId.toLowerCase()) {
-      activeBookIndex = index;
+	books.forEach((book, index) => {
+		if (book.book_id.toLowerCase() === bookId.toLowerCase()) {
+			activeBookIndex = index;
 
-      if (index - 1 >= 0) {
-        previousBookIndex = index - 1;
-      } else {
-        previousBookIndex = index;
-      }
-    }
-  });
+			if (index - 1 >= 0) {
+				previousBookIndex = index - 1;
+			} else {
+				previousBookIndex = index;
+			}
+		}
+	});
 
-  const previousBook =
-    fromJS(books[previousBookIndex]) || fromJS({ chapters: [], book_id: '' });
-  const activeBook =
-    fromJS(books[activeBookIndex]) || fromJS({ chapters: [], book_id: '' });
-  if (chapter - 1 === 0) {
-    // Goes to the last chapter in the previous book
-    return url({
-      audioType,
-      textId,
-      bookId: previousBook.get('book_id'),
-      chapter: previousBook.getIn(['chapters', -1]),
-      isHref,
-    });
-  }
-  // If the chapter number is greater than the active chapter then we have gone too far and need to get the previous chapter
-  const chapterIndex = activeBook
-    .get('chapters')
-    .findIndex((c) => c === chapter || c > chapter);
+	const previousBook =
+		fromJS(books[previousBookIndex]) || fromJS({ chapters: [], book_id: '' });
+	const activeBook =
+		fromJS(books[activeBookIndex]) || fromJS({ chapters: [], book_id: '' });
+	if (chapter - 1 === 0) {
+		// Goes to the last chapter in the previous book
+		return url({
+			audioType,
+			textId,
+			bookId: previousBook.get('book_id'),
+			chapter: previousBook.getIn(['chapters', -1]),
+			isHref,
+		});
+	}
+	// If the chapter number is greater than the active chapter then we have gone too far and need to get the previous chapter
+	const chapterIndex = activeBook
+		.get('chapters')
+		.findIndex((c) => c === chapter || c > chapter);
 
-  return url({ audioType, textId, bookId, chapter: chapterIndex, isHref });
+	if (!chapterIndex) {
+		return url({ audioType, textId, bookId, chapter, isHref });
+	}
+
+	return url({ audioType, textId, bookId, chapter: chapterIndex, isHref });
 };

--- a/app/utils/getPreviousChapterUrl.js
+++ b/app/utils/getPreviousChapterUrl.js
@@ -2,123 +2,123 @@ import { fromJS } from 'immutable';
 import url from './hrefLinkOrAsLink';
 
 export default ({
-	books,
-	chapter,
-	bookId,
-	textId,
-	verseNumber,
-	text: chapterText,
-	isHref,
-	audioType,
+  books,
+  chapter,
+  bookId,
+  textId,
+  verseNumber,
+  text: chapterText,
+  isHref,
+  audioType,
 }) => {
-	if (!books || !books.length) {
-		return url({ audioType, textId, bookId, chapter, isHref });
-	}
-	if (verseNumber && chapterText.length) {
-		const prevVerse = parseInt(verseNumber, 10) - 1 || 1;
-		const lastVerse = chapterText.length;
-		// Is it past the max verses for the chapter?
-		// if not increment it by 1
-		if (prevVerse <= lastVerse && prevVerse > 0) {
-			// Verse was valid
+  if (!books || !books.length) {
+    return url({ audioType, textId, bookId, chapter, isHref });
+  }
+  if (verseNumber && chapterText.length) {
+    const prevVerse = parseInt(verseNumber, 10) - 1 || 1;
+    const lastVerse = chapterText.length;
+    // Is it past the max verses for the chapter?
+    // if not increment it by 1
+    if (prevVerse <= lastVerse && prevVerse > 0) {
+      // Verse was valid
 
-			return url({
-				audioType,
-				textId,
-				bookId,
-				chapter,
-				nextVerse: prevVerse,
-				isHref,
-			});
-		} else if (prevVerse < 0) {
-			// Verse was below valid range
+      return url({
+        audioType,
+        textId,
+        bookId,
+        chapter,
+        nextVerse: prevVerse,
+        isHref,
+      });
+    } else if (prevVerse < 0) {
+      // Verse was below valid range
 
-			return url({
-				audioType,
-				textId,
-				bookId,
-				chapter,
-				nextVerse: '1',
-				isHref,
-			});
-		} else if (prevVerse > lastVerse) {
-			// Verse was above valid range
+      return url({
+        audioType,
+        textId,
+        bookId,
+        chapter,
+        nextVerse: '1',
+        isHref,
+      });
+    } else if (prevVerse > lastVerse) {
+      // Verse was above valid range
 
-			return url({
-				audioType,
-				textId,
-				bookId,
-				chapter,
-				nextVerse: lastVerse,
-				isHref,
-			});
-		}
-	} else if (verseNumber) {
-		const nextVerse = parseInt(verseNumber, 10) - 1 || 1;
+      return url({
+        audioType,
+        textId,
+        bookId,
+        chapter,
+        nextVerse: lastVerse,
+        isHref,
+      });
+    }
+  } else if (verseNumber) {
+    const nextVerse = parseInt(verseNumber, 10) - 1 || 1;
 
-		if (nextVerse && nextVerse > 0) {
-			// The next verse is within a valid range
+    if (nextVerse && nextVerse > 0) {
+      // The next verse is within a valid range
 
-			return url({ audioType, textId, bookId, chapter, nextVerse, isHref });
-		} else if (nextVerse < 0) {
-			// The next verse is below 0 and thus invalid
+      return url({ audioType, textId, bookId, chapter, nextVerse, isHref });
+    } else if (nextVerse < 0) {
+      // The next verse is below 0 and thus invalid
 
-			return url({
-				audioType,
-				textId,
-				bookId,
-				chapter,
-				nextVerse: '1',
-				isHref,
-			});
-		}
-	}
+      return url({
+        audioType,
+        textId,
+        bookId,
+        chapter,
+        nextVerse: '1',
+        isHref,
+      });
+    }
+  }
 
-	if (
-		books[0] &&
-		bookId.toLowerCase() === books[0].book_id.toLowerCase() &&
-		chapter - 1 === 0
-	) {
-		return url({ audioType, textId, bookId, chapter, isHref });
-	}
+  if (
+    books[0] &&
+    bookId.toLowerCase() === books[0].book_id.toLowerCase() &&
+    chapter - 1 === 0
+  ) {
+    return url({ audioType, textId, bookId, chapter, isHref });
+  }
 
-	let activeBookIndex;
-	let previousBookIndex;
+  let activeBookIndex;
+  let previousBookIndex;
 
-	books.forEach((book, index) => {
-		if (book.book_id.toLowerCase() === bookId.toLowerCase()) {
-			activeBookIndex = index;
+  books.forEach((book, index) => {
+    if (book.book_id.toLowerCase() === bookId.toLowerCase()) {
+      activeBookIndex = index;
 
-			if (index - 1 >= 0) {
-				previousBookIndex = index - 1;
-			} else {
-				previousBookIndex = index;
-			}
-		}
-	});
+      if (index - 1 >= 0) {
+        previousBookIndex = index - 1;
+      } else {
+        previousBookIndex = index;
+      }
+    }
+  });
 
-	const previousBook =
-		fromJS(books[previousBookIndex]) || fromJS({ chapters: [], book_id: '' });
-	const activeBook =
-		fromJS(books[activeBookIndex]) || fromJS({ chapters: [], book_id: '' });
-	if (chapter - 1 === 0) {
-		// Goes to the last chapter in the previous book
-		return url({
-			audioType,
-			textId,
-			bookId: previousBook.get('book_id'),
-			chapter: previousBook.getIn(['chapters', -1]),
-			isHref,
-		});
-	}
-	// If the chapter number is greater than the active chapter then we have gone too far and need to get the previous chapter
-	const chapterIndex = activeBook
-		.get('chapters')
-		.findIndex((c) => c === chapter || c > chapter);
+  const previousBook =
+    fromJS(books[previousBookIndex]) || fromJS({ chapters: [], book_id: '' });
+  const activeBook =
+    fromJS(books[activeBookIndex]) || fromJS({ chapters: [], book_id: '' });
+  if (chapter - 1 === 0) {
+    // Goes to the last chapter in the previous book
+    return url({
+      audioType,
+      textId,
+      bookId: previousBook.get('book_id'),
+      chapter: previousBook.getIn(['chapters', -1]),
+      isHref,
+    });
+  }
+  // If the chapter number is greater than the active chapter then we have gone too far and need to get the previous chapter
+  const chapterIndex = activeBook
+    .get('chapters')
+    .findIndex((c) => c === chapter || c > chapter);
 
-	if (!chapterIndex) {
-		return url({ audioType, textId, bookId, chapter, isHref });
-	}
+  if (!chapterIndex) {
+    return url({ audioType, textId, bookId, chapter, isHref });
+  }
 
-	return url({ audioType, textId, bookId, chapter: chapterIndex, isHref });
+  return url({ audioType, textId, bookId, chapter: chapterIndex, isHref });
 };

--- a/app/utils/getValidFilesetsByBook.js
+++ b/app/utils/getValidFilesetsByBook.js
@@ -1,6 +1,4 @@
-import {
-	FILESET_SIZE_COMPLETE,
-} from '../constants/bibleFileset';
+import { FILESET_SIZE_COMPLETE } from '../constants/bibleFileset';
 
 /**
  * Filter the list of plain Fileset Ids to include only those that belong to the same testament as the given book.
@@ -14,27 +12,47 @@ const getValidFilesetsByBook = (
 	book,
 	filesetIdsForBookMetadata,
 	filesets,
+	filesetIdsWithBooksAllowed,
 ) => {
 	const idsForBookMetadataIndexed = {};
+	const filesetWithBooksAllowedIndexed = filesetIdsWithBooksAllowed.reduce(
+		(accum, fileset) => ({ ...accum, ...fileset }),
+		{},
+	);
 
 	filesetIdsForBookMetadata.forEach((fileset) => {
-		if (fileset[1]) {
-			idsForBookMetadataIndexed[fileset[1]] = {
-				type: fileset[0],
-				id: fileset[1],
-				testament: fileset[2],
+		const filesetId = fileset[1];
+		const filesetType = fileset[0];
+		const filesetSize = fileset[2];
+
+		if (filesetId) {
+			const booksAllowed = {};
+			if (filesetWithBooksAllowedIndexed[filesetId]) {
+				filesetWithBooksAllowedIndexed[filesetId].forEach((bookAllowed) => {
+					booksAllowed[bookAllowed.book_id] = true;
+				});
+			}
+
+			idsForBookMetadataIndexed[filesetId] = {
+				type: filesetType,
+				id: filesetId,
+				testament: filesetSize,
+				booksAllowed,
 			};
 		}
 	});
 
-	return filesets.filter((fileset) =>
-		// 1. If the Fileset testament is NTP, it will only be considered valid if the testament of the book is also NT.
-		// 2. A Fileset with a testament code of C is considered valid because it includes both the Old and New Testaments.
-		//    This is because the C size code denotes a fileset that includes content from both testaments.
-		 (
-			idsForBookMetadataIndexed[fileset.id]?.testament === FILESET_SIZE_COMPLETE ||
-			idsForBookMetadataIndexed[fileset.id]?.testament.includes(book.testament)
-		)
+	return filesets.filter(
+		(fileset) =>
+			// 1. If the Fileset testament is NTP, it will only be considered valid if the testament of the book is also NT.
+			// 2. A Fileset with a testament code of C is considered valid because it includes both the Old and New Testaments.
+			//    This is because the C size code denotes a fileset that includes content from both testaments.
+			(idsForBookMetadataIndexed[fileset.id]?.testament ===
+				FILESET_SIZE_COMPLETE ||
+				idsForBookMetadataIndexed[fileset.id]?.testament.includes(
+					book.testament,
+				)) &&
+			idsForBookMetadataIndexed[fileset.id]?.booksAllowed[book.book_id],
 	);
 };
 

--- a/app/utils/getVersionForLanguage.js
+++ b/app/utils/getVersionForLanguage.js
@@ -4,81 +4,81 @@ import getBookMetaData from './getBookMetaData';
 import getFirstChapterReference from './getFirstChapterReference';
 
 export const getVersionForLanguage = async ({
-  languageCode,
-  activeBookId,
-  activeChapter,
+	languageCode,
+	activeBookId,
+	activeChapter,
 }) => {
-  const requestUrl = `${process.env.BASE_API_ROUTE}/bibles?key=${process.env.DBP_API_KEY}&language_code=${languageCode}&v=4`;
+	const requestUrl = `${process.env.BASE_API_ROUTE}/bibles?key=${process.env.DBP_API_KEY}&language_code=${languageCode}&v=4`;
 
-  try {
-    const response = await request(requestUrl);
-    // Only need first index since there is only one reported bible in this source
-    const bible = response.data.map((bibleObject) => ({
-      ...bibleObject,
-      filesets: Object.values(bibleObject.filesets).reduce(
-        (allFilesets, currentFilesets) => [...allFilesets, ...currentFilesets],
-        [],
-      ),
-    }))[0];
-    const hasAudio = bible.filesets.some(
-      (set) => set.type === 'audio_drama' || set.type === 'audio',
-    );
-    const hasVideo = bible.filesets.some((set) => set.type === 'video_stream');
-    // If there is audio then try to default to drama
-    // Otherwise use plain audio
-    const audioType =
-      hasAudio && bible.filesets.some((set) => set.type === 'audio_drama')
-        ? 'audio_drama'
-        : 'audio';
-    let versionHref = getUrl({
-      textId: bible.abbr,
-      bookId: activeBookId,
-      chapter: activeChapter,
-      audioType,
-      isHref: true,
-    });
-    let versionAs = getUrl({
-      textId: bible.abbr,
-      bookId: activeBookId,
-      chapter: activeChapter,
-      audioType,
-      isHref: false,
-    });
+	try {
+		const response = await request(requestUrl);
+		// Only need first index since there is only one reported bible in this source
+		const bible = response.data.map((bibleObject) => ({
+			...bibleObject,
+			filesets: Object.values(bibleObject.filesets).reduce(
+				(allFilesets, currentFilesets) => [...allFilesets, ...currentFilesets],
+				[],
+			),
+		}))[0];
+		const hasAudio = bible.filesets.some(
+			(set) => set.type === 'audio_drama' || set.type === 'audio',
+		);
+		const hasVideo = bible.filesets.some((set) => set.type === 'video_stream');
+		// If there is audio then try to default to drama
+		// Otherwise use plain audio
+		const audioType =
+			hasAudio && bible.filesets.some((set) => set.type === 'audio_drama')
+				? 'audio_drama'
+				: 'audio';
+		let versionHref = getUrl({
+			textId: bible.abbr,
+			bookId: activeBookId,
+			chapter: activeChapter,
+			audioType,
+			isHref: true,
+		});
+		let versionAs = getUrl({
+			textId: bible.abbr,
+			bookId: activeBookId,
+			chapter: activeChapter,
+			audioType,
+			isHref: false,
+		});
 
-    if (!JSON.parse(sessionStorage.getItem('bible_is_maintain_location'))) {
-      // Find url and push that one
-      const [filteredMetadata, allMetadata] = await getBookMetaData({
-        idsForBookMetadata: bible.filesets.map((set) => [set.type, set.id]),
-      });
+		if (!JSON.parse(sessionStorage.getItem('bible_is_maintain_location'))) {
+			// Find url and push that one
+			const [filteredMetadata, allMetadata] = await getBookMetaData({
+				idsForBookMetadata: bible.filesets.map((set) => [set.type, set.id]),
+			});
 
-      const bookChapterUrl = getFirstChapterReference(
-        bible.filesets,
-        hasVideo,
-        allMetadata,
-        filteredMetadata,
-        audioType,
-      );
+			const bookChapterUrl = getFirstChapterReference(
+				bible.filesets,
+				hasVideo,
+				allMetadata,
+				filteredMetadata,
+				audioType,
+			);
 
-      // Need to parse out the bookChapterUrl to create the href version for the server
-      // Safe to access 0th element for \w of match since it always returns a string
-      const bookId = bookChapterUrl.match(/\w*/)[0]; // Get first word which is bookId
-      const chapterId = bookChapterUrl.match(/\/\w*/)[0].slice(1); // get second part of url
-      const query =
-        bookChapterUrl.match(/\?.*/) &&
-        bookChapterUrl.match(/\?.*/)[0].replace('?', '&'); // Get any query params at the end
+			// Need to parse out the bookChapterUrl to create the href version for the server
+			// Safe to access 0th element for \w of match since it always returns a string
+			const bookId = bookChapterUrl.match(/\w*/)[0]; // Get first word which is bookId
+			const chapterId = bookChapterUrl.match(/\/\w*/)[0].slice(1); // get second part of url
+			const query =
+				bookChapterUrl.match(/\?.*/) &&
+				bookChapterUrl.match(/\?.*/)[0].replace('?', '&'); // Get any query params at the end
 
-      // Set href and as to correct place
-      versionHref = `/app?bibleId=${
-        bible.abbr
-      }&bookId=${bookId}&chapter=${chapterId}${query}`;
-      versionAs = `/bible/${bible.abbr}/${bookChapterUrl}`;
-    }
+			// Set href and as to correct place
+			versionHref = `/app?bibleId=${
+				bible.abbr
+			}&bookId=${bookId}&chapter=${chapterId}${query || ''}`;
+			versionAs = `/bible/${bible.abbr}/${bookChapterUrl}`;
+		}
 
-    return { versionHref, versionAs };
-  } catch (err) {
-    if (process.env.NODE_ENV === 'development') {
-      console.error(err); // eslint-disable-line no-console
-    }
-    return { versionHref: '', versionAs: '' };
-  }
+		return { versionHref, versionAs };
+	} catch (err) {
+		if (process.env.NODE_ENV === 'development') {
+			console.error(err); // eslint-disable-line no-console
+		}
+		return { versionHref: '', versionAs: '' };
+	}
 };

--- a/app/utils/getVersionForLanguage.js
+++ b/app/utils/getVersionForLanguage.js
@@ -4,81 +4,81 @@ import getBookMetaData from './getBookMetaData';
 import getFirstChapterReference from './getFirstChapterReference';
 
 export const getVersionForLanguage = async ({
-	languageCode,
-	activeBookId,
-	activeChapter,
+  languageCode,
+  activeBookId,
+  activeChapter,
 }) => {
-	const requestUrl = `${process.env.BASE_API_ROUTE}/bibles?key=${process.env.DBP_API_KEY}&language_code=${languageCode}&v=4`;
+  const requestUrl = `${process.env.BASE_API_ROUTE}/bibles?key=${process.env.DBP_API_KEY}&language_code=${languageCode}&v=4`;
 
-	try {
-		const response = await request(requestUrl);
-		// Only need first index since there is only one reported bible in this source
-		const bible = response.data.map((bibleObject) => ({
-			...bibleObject,
-			filesets: Object.values(bibleObject.filesets).reduce(
-				(allFilesets, currentFilesets) => [...allFilesets, ...currentFilesets],
-				[],
-			),
-		}))[0];
-		const hasAudio = bible.filesets.some(
-			(set) => set.type === 'audio_drama' || set.type === 'audio',
-		);
-		const hasVideo = bible.filesets.some((set) => set.type === 'video_stream');
-		// If there is audio then try to default to drama
-		// Otherwise use plain audio
-		const audioType =
-			hasAudio && bible.filesets.some((set) => set.type === 'audio_drama')
-				? 'audio_drama'
-				: 'audio';
-		let versionHref = getUrl({
-			textId: bible.abbr,
-			bookId: activeBookId,
-			chapter: activeChapter,
-			audioType,
-			isHref: true,
-		});
-		let versionAs = getUrl({
-			textId: bible.abbr,
-			bookId: activeBookId,
-			chapter: activeChapter,
-			audioType,
-			isHref: false,
-		});
+  try {
+    const response = await request(requestUrl);
+    // Only need first index since there is only one reported bible in this source
+    const bible = response.data.map((bibleObject) => ({
+      ...bibleObject,
+      filesets: Object.values(bibleObject.filesets).reduce(
+        (allFilesets, currentFilesets) => [...allFilesets, ...currentFilesets],
+        [],
+      ),
+    }))[0];
+    const hasAudio = bible.filesets.some(
+      (set) => set.type === 'audio_drama' || set.type === 'audio',
+    );
+    const hasVideo = bible.filesets.some((set) => set.type === 'video_stream');
+    // If there is audio then try to default to drama
+    // Otherwise use plain audio
+    const audioType =
+      hasAudio && bible.filesets.some((set) => set.type === 'audio_drama')
+        ? 'audio_drama'
+        : 'audio';
+    let versionHref = getUrl({
+      textId: bible.abbr,
+      bookId: activeBookId,
+      chapter: activeChapter,
+      audioType,
+      isHref: true,
+    });
+    let versionAs = getUrl({
+      textId: bible.abbr,
+      bookId: activeBookId,
+      chapter: activeChapter,
+      audioType,
+      isHref: false,
+    });
 
-		if (!JSON.parse(sessionStorage.getItem('bible_is_maintain_location'))) {
-			// Find url and push that one
-			const [filteredMetadata, allMetadata] = await getBookMetaData({
-				idsForBookMetadata: bible.filesets.map((set) => [set.type, set.id]),
-			});
+    if (!JSON.parse(sessionStorage.getItem('bible_is_maintain_location'))) {
+      // Find url and push that one
+      const [filteredMetadata, allMetadata] = await getBookMetaData({
+        idsForBookMetadata: bible.filesets.map((set) => [set.type, set.id]),
+      });
 
-			const bookChapterUrl = getFirstChapterReference(
-				bible.filesets,
-				hasVideo,
-				allMetadata,
-				filteredMetadata,
-				audioType,
-			);
+      const bookChapterUrl = getFirstChapterReference(
+        bible.filesets,
+        hasVideo,
+        allMetadata,
+        filteredMetadata,
+        audioType,
+      );
 
-			// Need to parse out the bookChapterUrl to create the href version for the server
-			// Safe to access 0th element for \w of match since it always returns a string
-			const bookId = bookChapterUrl.match(/\w*/)[0]; // Get first word which is bookId
-			const chapterId = bookChapterUrl.match(/\/\w*/)[0].slice(1); // get second part of url
-			const query =
-				bookChapterUrl.match(/\?.*/) &&
-				bookChapterUrl.match(/\?.*/)[0].replace('?', '&'); // Get any query params at the end
+      // Need to parse out the bookChapterUrl to create the href version for the server
+      // Safe to access 0th element for \w of match since it always returns a string
+      const bookId = bookChapterUrl.match(/\w*/)[0]; // Get first word which is bookId
+      const chapterId = bookChapterUrl.match(/\/\w*/)[0].slice(1); // get second part of url
+      const query =
+        bookChapterUrl.match(/\?.*/) &&
+        bookChapterUrl.match(/\?.*/)[0].replace('?', '&'); // Get any query params at the end
 
-			// Set href and as to correct place
-			versionHref = `/app?bibleId=${
-				bible.abbr
-			}&bookId=${bookId}&chapter=${chapterId}${query || ''}`;
-			versionAs = `/bible/${bible.abbr}/${bookChapterUrl}`;
-		}
+      // Set href and as to correct place
+      versionHref = `/app?bibleId=${
+        bible.abbr
+      }&bookId=${bookId}&chapter=${chapterId}${query || ''}`;
+      versionAs = `/bible/${bible.abbr}/${bookChapterUrl}`;
+    }
 
-		return { versionHref, versionAs };
-	} catch (err) {
-		if (process.env.NODE_ENV === 'development') {
-			console.error(err); // eslint-disable-line no-console
-		}
-		return { versionHref: '', versionAs: '' };
-	}
+    return { versionHref, versionAs };
+  } catch (err) {
+    if (process.env.NODE_ENV === 'development') {
+      console.error(err); // eslint-disable-line no-console
+    }
+    return { versionHref: '', versionAs: '' };
+  }
 };

--- a/app/utils/hrefLinkOrAsLink.js
+++ b/app/utils/hrefLinkOrAsLink.js
@@ -4,6 +4,14 @@ export default ({ textId, bookId, chapter, nextVerse, isHref, audioType }) => {
 		? `${isHref ? '&' : '?'}audio_type=${audioType}`
 		: '';
 
+	if (!bookId) {
+		return `${baseUrl}/${textId}`;
+	}
+
+	if (!chapter) {
+		return `${baseUrl}/${textId}/${bookId}`;
+	}
+
 	if (isHref) {
 		if (nextVerse) {
 			return `${baseUrl}bibleId=${textId}&bookId=${bookId}&chapter=${chapter}&verse=${nextVerse}${params}`;

--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
   },
   "lint-staged": {
     "*.{js,json,scss,md}": [
-      "prettier --arrow-parens=always --use-tabs --write --single-quote --trailing-comma=all",
       "eslint --ignore-path .gitignore --ignore-pattern internals/scripts",
       "git add"
     ]

--- a/pages/app.js
+++ b/pages/app.js
@@ -6,27 +6,27 @@
  */
 
 /*
-* Todo: Items that need to be done before production
-* todo: Replace all tabIndex 0 values with what they should actually be
-* todo: Set up a function to init all of the plugins that rely on the browser
-* todo: Update site url to match the live site domain name
-* todo: Use cookies instead of session and local storage for all user settings (involves user approval before it can be utilized)
-* todo: Remove the script for providing feedback
-* */
+ * Todo: Items that need to be done before production
+ * todo: Replace all tabIndex 0 values with what they should actually be
+ * todo: Set up a function to init all of the plugins that rely on the browser
+ * todo: Update site url to match the live site domain name
+ * todo: Use cookies instead of session and local storage for all user settings (involves user approval before it can be utilized)
+ * todo: Remove the script for providing feedback
+ * */
 // Needed for redux-saga es6 generator support
 import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import Head from 'next/head';
-import Router, { useRouter } from 'next/router';
+import { useRouter } from 'next/router';
 import axios from 'axios';
 import cachedFetch, { overrideCache } from '../app/utils/cachedFetch';
 import HomePage from '../app/containers/HomePage';
 import getinitialChapterData from '../app/utils/getInitialChapterData';
 import getValidFilesetsByBook from '../app/utils/getValidFilesetsByBook';
 import {
-  setChapterTextLoadingState,
-  setUA,
+	setChapterTextLoadingState,
+	setUA,
 } from '../app/containers/HomePage/actions';
 import svg4everybody from '../app/utils/svgPolyfill';
 import parseCookie from '../app/utils/parseCookie';
@@ -40,699 +40,718 @@ import geFilesetsForBible from '../app/utils/geFilesetsForBible';
 import hasFilesetVideo from '../app/utils/hasFilesetVideo';
 import removeStoriesFilesets from '../app/utils/removeStoriesFilesets';
 import {
-  FILESET_TYPE_TEXT_PLAIN,
-  FILESET_TYPE_TEXT_FORMAT,
-  FILESET_TYPE_AUDIO_DRAMA,
-  FILESET_TYPE_AUDIO,
+	FILESET_TYPE_TEXT_PLAIN,
+	FILESET_TYPE_TEXT_FORMAT,
+	FILESET_TYPE_AUDIO_DRAMA,
+	FILESET_TYPE_AUDIO,
 } from '../app/constants/bibleFileset';
 
 function AppContainer(props) {
-  const router = useRouter();
-  const [prevFormattedText, setPrevFormattedText] = useState('');
+	const router = useRouter();
+	const [prevFormattedText, setPrevFormattedText] = useState('');
 
-  /* eslint-disable no-undef */
-  const handleRouteChange = (url) => {
-    /* eslint-enable no-undef */
-    // Pause audio
-    // Start loading spinner for text
-    // Close any open menus
-    // Remove current audio source - (may fix item 1)
-    // TODO: Probably need to get the new highlights here or at least start the process for getting them
-    if (typeof dataLayer !== 'undefined') {
-      try {
-        dataLayer.push({
-          event: 'pageview',
-          page: {
-            path: url,
-            title: url,
-          },
-        });
-      } catch (err) {
-        console.error('Google tag manager did not capture pageview: ', err); // eslint-disable-line no-console
-      }
-    }
-    props.dispatch(setChapterTextLoadingState({ state: true }));
-  };
+	/* eslint-disable no-undef */
+	const handleRouteChange = (url) => {
+		/* eslint-enable no-undef */
+		// Pause audio
+		// Start loading spinner for text
+		// Close any open menus
+		// Remove current audio source - (may fix item 1)
+		// TODO: Probably need to get the new highlights here or at least start the process for getting them
+		if (typeof dataLayer !== 'undefined') {
+			try {
+				dataLayer.push({
+					event: 'pageview',
+					page: {
+						path: url,
+						title: url,
+					},
+				});
+			} catch (err) {
+				console.error('Google tag manager did not capture pageview: ', err); // eslint-disable-line no-console
+			}
+		}
+		props.dispatch(setChapterTextLoadingState({ state: true }));
+	};
 
-  // eslint-disable-line no-undef
-  useEffect(() => {
-    if (
-      localStorage.getItem('reducerVersion') !== REDUX_PERSIST.reducerVersion
-    ) {
-      reconcilePersistedState(
-        ['settings', 'searchContainer', 'profile'],
-        REDUX_PERSIST.reducerKey,
-      );
-      localStorage.setItem('reducerVersion', REDUX_PERSIST.reducerVersion);
-    }
-    // If the page was served from the server then I need to cache the data for this route
-    if (props.isFromServer) {
-      props.fetchedUrls.forEach((url) => {
-        if (url.data.error || url.data.errors) {
-          overrideCache(url.href, {}, 1);
-        } else {
-          overrideCache(url.href, url.data);
-        }
-      });
-    }
-    // If undefined gets stored in local storage it cannot be parsed so I have to compare strings
-    if (props?.userProfile?.userId) {
-      props.dispatch({
-        type: 'GET_INITIAL_ROUTE_STATE_PROFILE',
-        profile: {
-          userId: props.userProfile.userId,
-          userAuthenticated: !!props.userProfile.userId,
-          userProfile: {
-            email:
-              props.userProfile.email || '',
-            name:
-              props.userProfile.name || '',
-            nickname:
-              props.userProfile.name || '',
-          },
-        },
-      });
-    } else if (sessionStorage?.getItem('bible_is_user_id')) {
-      props.dispatch({
-        type: 'GET_INITIAL_ROUTE_STATE_PROFILE',
-        profile: {
-          userId: sessionStorage.getItem('bible_is_user_id'),
-          userAuthenticated: !!sessionStorage.getItem('bible_is_user_id'),
-          userProfile: {
-            email: sessionStorage.getItem('bible_is_user_email') || '',
-            name: sessionStorage.getItem('bible_is_user_name') || '',
-            nickname: sessionStorage.getItem('bible_is_user_nickname') || '',
-          },
-        },
-      });
-    }
-    const redLetter =
-      !!props.formattedText &&
-      !!(
-        props.formattedText.includes('class="wj"') ||
-        props.formattedText.includes("class='wj'")
-      );
-    props.dispatch({
-      type: 'GET_INITIAL_ROUTE_STATE_SETTINGS',
-      redLetter,
-      crossReferences:
-        !!props.formattedText &&
-        !!(
-          props.formattedText.includes('class="ft"') ||
-          props.formattedText.includes('class="xt"')
-        ),
-    });
-    props.dispatch(setChapterTextLoadingState({ state: false }));
+	// eslint-disable-line no-undef
+	useEffect(() => {
+		if (
+			localStorage.getItem('reducerVersion') !== REDUX_PERSIST.reducerVersion
+		) {
+			reconcilePersistedState(
+				['settings', 'searchContainer', 'profile'],
+				REDUX_PERSIST.reducerKey,
+			);
+			localStorage.setItem('reducerVersion', REDUX_PERSIST.reducerVersion);
+		}
+		// If the page was served from the server then I need to cache the data for this route
+		if (props.isFromServer) {
+			props.fetchedUrls.forEach((url) => {
+				if (url.data.error || url.data.errors) {
+					overrideCache(url.href, {}, 1);
+				} else {
+					overrideCache(url.href, url.data);
+				}
+			});
+		}
+		// If undefined gets stored in local storage it cannot be parsed so I have to compare strings
+		if (props?.userProfile?.userId) {
+			props.dispatch({
+				type: 'GET_INITIAL_ROUTE_STATE_PROFILE',
+				profile: {
+					userId: props.userProfile.userId,
+					userAuthenticated: !!props.userProfile.userId,
+					userProfile: {
+						email: props.userProfile.email || '',
+						name: props.userProfile.name || '',
+						nickname: props.userProfile.name || '',
+					},
+				},
+			});
+		} else if (sessionStorage?.getItem('bible_is_user_id')) {
+			props.dispatch({
+				type: 'GET_INITIAL_ROUTE_STATE_PROFILE',
+				profile: {
+					userId: sessionStorage.getItem('bible_is_user_id'),
+					userAuthenticated: !!sessionStorage.getItem('bible_is_user_id'),
+					userProfile: {
+						email: sessionStorage.getItem('bible_is_user_email') || '',
+						name: sessionStorage.getItem('bible_is_user_name') || '',
+						nickname: sessionStorage.getItem('bible_is_user_nickname') || '',
+					},
+				},
+			});
+		}
+		const redLetter =
+			!!props.formattedText &&
+			!!(
+				props.formattedText.includes('class="wj"') ||
+				props.formattedText.includes("class='wj'")
+			);
+		props.dispatch({
+			type: 'GET_INITIAL_ROUTE_STATE_SETTINGS',
+			redLetter,
+			crossReferences:
+				!!props.formattedText &&
+				!!(
+					props.formattedText.includes('class="ft"') ||
+					props.formattedText.includes('class="xt"')
+				),
+		});
+		props.dispatch(setChapterTextLoadingState({ state: false }));
 
-    if (props.isIe) {
-      props.dispatch(setUA());
-      if (
-        typeof svg4everybody === 'function' &&
-        typeof window !== 'undefined'
-      ) {
-        svg4everybody();
-      }
-    }
-  }, []);
+		if (props.isIe) {
+			props.dispatch(setUA());
+			if (
+				typeof svg4everybody === 'function' &&
+				typeof window !== 'undefined'
+			) {
+				svg4everybody();
+			}
+		}
+	}, []);
 
-  useEffect(() => {
-    // Intercept all route changes to ensure that the loading spinner starts
-    router.events.on('routeChangeStart', handleRouteChange);
+	useEffect(() => {
+		// Intercept all route changes to ensure that the loading spinner starts
+		router.events.on('routeChangeStart', handleRouteChange);
 
-    return () => {
-      router.events.off('routeChangeStart', handleRouteChange);
-    };
-  }, [router]);
+		return () => {
+			router.events.off('routeChangeStart', handleRouteChange);
+		};
+	}, [router]);
 
-  useEffect(() => {
-    if (props.formattedText !== prevFormattedText) {
-      const redLetter =
-        !!prevFormattedText &&
-        !!(
-          prevFormattedText.includes('class="wj"') ||
-          prevFormattedText.includes("class='wj'")
-        );
+	useEffect(() => {
+		if (props.formattedText !== prevFormattedText) {
+			const redLetter =
+				!!prevFormattedText &&
+				!!(
+					prevFormattedText.includes('class="wj"') ||
+					prevFormattedText.includes("class='wj'")
+				);
 
-      props.dispatch({
-        type: 'GET_INITIAL_ROUTE_STATE_SETTINGS',
-        redLetter,
-        crossReferences:
-          !!prevFormattedText &&
-          !!(
-            prevFormattedText.includes('class="ft"') ||
-            prevFormattedText.includes('class="xt"')
-          ),
-      });
-      setPrevFormattedText(props.formattedText);
-    }
-  }, [props.formattedText]);
-  const {
-    activeChapter,
-    chapterText,
-    activeBookName,
-    routeLocation,
-    initialPlaybackRate,
-    initialVolume,
-    isIe,
-  } = props;
-  // Defaulting description text to an empty string since no metadata is better than inaccurate metadata
-  const descriptionText =
-    chapterText && chapterText[0] ? `${chapterText[0].verse_text}...` : '';
+			props.dispatch({
+				type: 'GET_INITIAL_ROUTE_STATE_SETTINGS',
+				redLetter,
+				crossReferences:
+					!!prevFormattedText &&
+					!!(
+						prevFormattedText.includes('class="ft"') ||
+						prevFormattedText.includes('class="xt"')
+					),
+			});
+			setPrevFormattedText(props.formattedText);
+		}
+	}, [props.formattedText]);
 
-  const headTitle = `${activeBookName} ${activeChapter}${props.match?.params?.verse
-      ? `:${props.match.params.verse}`
-      : ''
-    } ${'| Bible.is'}`;
-    return (
-      <div>
-        <Head>
-          <meta name={'description'} content={descriptionText} />
-          <meta
-            property={'og:title'}
-            content={`${activeBookName} ${activeChapter}${
-              props.match?.params?.verse
-                ? `:${props.match.params.verse}`
-                : ''
-            } | Bible.is`}
-          />
-          <meta
-            property={'og:image'}
-            content={`${process.env.BASE_SITE_URL}/public/icon-310x310.png`}
-          />
-          <meta property={'og:image:width'} content={310} />
-          <meta property={'og:image:height'} content={310} />
-          <meta
-            property={'og:url'}
-            content={`${process.env.BASE_SITE_URL}/${routeLocation}`}
-          />
-          <meta property={'og:description'} content={descriptionText} />
-          <meta
-            name={'twitter:title'}
-            content={`${activeBookName} ${activeChapter}`}
-          />
-          <meta name={'twitter:description'} content={descriptionText} />
-          <title>
-            {headTitle}
-          </title>
-        </Head>
-        <HomePage
-          initialPlaybackRate={initialPlaybackRate}
-          initialVolume={initialVolume}
-          isIe={isIe}
-        />
-      </div>
-    );
+	useEffect(() => {
+		if (props.triggerRedirect.url && props.triggerRedirect.as) {
+			router.push(props.triggerRedirect.url, props.triggerRedirect.as);
+		}
+	}, [props.triggerRedirect.url, props.triggerRedirect.as]);
+
+	const {
+		activeChapter,
+		chapterText,
+		activeBookName,
+		routeLocation,
+		initialPlaybackRate,
+		initialVolume,
+		isIe,
+	} = props;
+	// Defaulting description text to an empty string since no metadata is better than inaccurate metadata
+	const descriptionText =
+		chapterText && chapterText[0] ? `${chapterText[0].verse_text}...` : '';
+
+	const headTitle = `${activeBookName} ${activeChapter}${
+		props.match?.params?.verse ? `:${props.match.params.verse}` : ''
+	} ${'| Bible.is'}`;
+	return (
+		<div>
+			<Head>
+				<meta name={'description'} content={descriptionText} />
+				<meta
+					property={'og:title'}
+					content={`${activeBookName} ${activeChapter}${
+						props.match?.params?.verse ? `:${props.match.params.verse}` : ''
+					} | Bible.is`}
+				/>
+				<meta
+					property={'og:image'}
+					content={`${process.env.BASE_SITE_URL}/public/icon-310x310.png`}
+				/>
+				<meta property={'og:image:width'} content={310} />
+				<meta property={'og:image:height'} content={310} />
+				<meta
+					property={'og:url'}
+					content={`${process.env.BASE_SITE_URL}/${routeLocation}`}
+				/>
+				<meta property={'og:description'} content={descriptionText} />
+				<meta
+					name={'twitter:title'}
+					content={`${activeBookName} ${activeChapter}`}
+				/>
+				<meta name={'twitter:description'} content={descriptionText} />
+				<title>{headTitle}</title>
+			</Head>
+			<HomePage
+				initialPlaybackRate={initialPlaybackRate}
+				initialVolume={initialVolume}
+				isIe={isIe}
+			/>
+		</div>
+	);
 }
 
 AppContainer.displayName = 'Main app';
 
 AppContainer.getInitialProps = async (context) => {
-  const { req, res: serverRes } = context;
-  const routeLocation = context.asPath;
-  const {
-    bookId = '',
-    chapter: chapterParam,
-    bibleId = 'ENGESV',
-    verse,
-    token,
-    userId: reqUserId,
-    userEmail = '',
-    userName = '',
-  } = context.query;
-  const userProfile = {
-    userId: reqUserId,
-    email: userEmail,
-    name: userName,
-    nickname: userName,
-  };
-  const tempChapter =
-    typeof chapterParam === 'string' && chapterParam.split('?')[0];
-  const chapter = tempChapter || chapter;
-  // Using let here because the cookie data can come from the server or the client
-  let audioParam = req && req.query.audio_type;
-  let userId = reqUserId || '';
-  let hasVideo = false;
-  let isFromServer = true;
-  let isAuthenticated = false;
-  let initialVolume = 1;
-  let initialPlaybackRate = 1;
-  let isIe = false;
-  let audioType = '';
+	const { req, res: serverRes } = context;
+	const routeLocation = context.asPath;
+	const {
+		bookId = '',
+		chapter: chapterParam,
+		bibleId = 'ENGESV',
+		verse,
+		token,
+		userId: reqUserId,
+		userEmail = '',
+		userName = '',
+	} = context.query;
+	const userProfile = {
+		userId: reqUserId,
+		email: userEmail,
+		name: userName,
+		nickname: userName,
+	};
+	const tempChapter =
+		typeof chapterParam === 'string' && chapterParam.split('?')[0];
+	const chapter = tempChapter || chapter;
+	// Using let here because the cookie data can come from the server or the client
+	let audioParam = req && req.query.audio_type;
+	let userId = reqUserId || '';
+	let hasVideo = false;
+	let isFromServer = true;
+	let isAuthenticated = false;
+	let initialVolume = 1;
+	let initialPlaybackRate = 1;
+	let isIe = false;
+	let audioType = '';
+	const triggerRedirect = {
+		url: null,
+		as: null,
+	};
 
-  if (req && req.query.audio_type) {
-    audioParam = req.query.audio_type;
-  } else if (!req) {
-    audioParam = context.query.audio_type;
-  }
+	if (req?.query.audio_type) {
+		audioParam = req.query.audio_type;
+	} else if (!req) {
+		audioParam = context.query.audio_type;
+	}
 
-  if (req && req.headers) {
-    isIe = isUserAgentInternetExplorer(req.headers['user-agent']);
-  }
+	if (req?.headers) {
+		isIe = isUserAgentInternetExplorer(req.headers['user-agent']);
+	}
 
-  let cookieData = null;
+	let cookieData = null;
 
-  if (req && req.headers.cookie) {
-    // Get all cookies that the page needs
-    cookieData = parseCookie(req.headers.cookie);
+	if (req?.headers.cookie) {
+		// Get all cookies that the page needs
+		cookieData = parseCookie(req.headers.cookie);
 
-    if (cookieData.bible_is_audio_type) {
-      audioType = cookieData.bible_is_audio_type;
-    }
+		if (cookieData.bible_is_audio_type) {
+			audioType = cookieData.bible_is_audio_type;
+		}
 
-    if (userId) {
-      // Authentication Information
-      isAuthenticated = !!userId;
-      // User Profile
-      userProfile.email = userEmail;
-      userProfile.nickname = userName;
-      userProfile.name = userName;
-      userProfile.userId = userId;
-      // Avatar is a placeholder for when we actually build the rest of that functionality
-      userProfile.avatar = '';
-    } else if (!userId) {
-      // Authentication Information
-      userId = cookieData.bible_is_user_id || '';
-      isAuthenticated = !!cookieData.bible_is_user_id;
-      // User Profile
-      userProfile.email = cookieData.bible_is_email || '';
-      userProfile.nickname = cookieData.bible_is_name || '';
-      userProfile.name = cookieData.bible_is_name;
-      // Avatar is a placeholder for when we actually build the rest of that functionality
-      userProfile.avatar = '';
-    }
+		if (userId) {
+			// Authentication Information
+			isAuthenticated = !!userId;
+			// User Profile
+			userProfile.email = userEmail;
+			userProfile.nickname = userName;
+			userProfile.name = userName;
+			userProfile.userId = userId;
+			// Avatar is a placeholder for when we actually build the rest of that functionality
+			userProfile.avatar = '';
+		} else if (!userId) {
+			// Authentication Information
+			userId = cookieData.bible_is_user_id || '';
+			isAuthenticated = !!cookieData.bible_is_user_id;
+			// User Profile
+			userProfile.email = cookieData.bible_is_email || '';
+			userProfile.nickname = cookieData.bible_is_name || '';
+			userProfile.name = cookieData.bible_is_name;
+			// Avatar is a placeholder for when we actually build the rest of that functionality
+			userProfile.avatar = '';
+		}
 
-    // Audio Player
-    initialVolume =
-      cookieData.bible_is_volume === 0 ? 0 : cookieData.bible_is_volume || 1;
-    initialPlaybackRate = cookieData.bible_is_playbackrate || 1;
+		// Audio Player
+		initialVolume =
+			cookieData.bible_is_volume === 0 ? 0 : cookieData.bible_is_volume || 1;
+		initialPlaybackRate = cookieData.bible_is_playbackrate || 1;
 
-    // Handle oauth code if there is one
-    if (cookieData.bible_is_cb_code && cookieData.bible_is_provider) {
-      await fetch(
-        `${process.env.BASE_API_ROUTE}/login/${
-          cookieData.bible_is_provider
-        }/callback?v=4&project_id=${process.env.NOTES_PROJECT_ID}&key=${
-          process.env.DBP_API_KEY
-        }&alt_url=true&code=${cookieData.bible_is_cb_code}`,
-      ).then((body) => body.data);
-    }
+		// Handle oauth code if there is one
+		if (cookieData.bible_is_cb_code && cookieData.bible_is_provider) {
+			await fetch(
+				`${process.env.BASE_API_ROUTE}/login/${cookieData.bible_is_provider}/callback?v=4&project_id=${process.env.NOTES_PROJECT_ID}&key=${process.env.DBP_API_KEY}&alt_url=true&code=${cookieData.bible_is_cb_code}`,
+			).then((body) => body.data);
+		}
 
-    isFromServer = false;
-  } else if (typeof document !== 'undefined' && document.cookie) {
-    cookieData = parseCookie(document.cookie);
-    if (cookieData.bible_is_audio_type) {
-      audioType = cookieData.bible_is_audio_type;
-    }
+		isFromServer = false;
+	} else if (typeof document !== 'undefined' && document.cookie) {
+		cookieData = parseCookie(document.cookie);
+		if (cookieData.bible_is_audio_type) {
+			audioType = cookieData.bible_is_audio_type;
+		}
 
-    if (userId) {
-      // Authentication Information
-      isAuthenticated = !!userId;
-      // User Profile
-      userProfile.email = userEmail;
-      userProfile.nickname = userName;
-      userProfile.name = userName;
-      userProfile.userId = userId;
-      // Avatar is a placeholder for when we actually build the rest of that functionality
-      userProfile.avatar = '';
-    } else if (!userId) {
-      // Authentication Information
-      userId = localStorage.getItem('bible_is_user_id') || '';
-      isAuthenticated = !!localStorage.getItem('bible_is_user_id') || '';
-      // User Profile
-      userProfile.email = localStorage.getItem('bible_is_user_email') || '';
-      userProfile.nickname = localStorage.getItem('bible_is_user_name') || '';
-      userProfile.name = localStorage.getItem('bible_is_user_nickname');
-      userProfile.userId = userId;
-      // Avatar is a placeholder for when we actually build the rest of that functionality
-      userProfile.avatar = '';
-    }
+		if (userId) {
+			// Authentication Information
+			isAuthenticated = !!userId;
+			// User Profile
+			userProfile.email = userEmail;
+			userProfile.nickname = userName;
+			userProfile.name = userName;
+			userProfile.userId = userId;
+			// Avatar is a placeholder for when we actually build the rest of that functionality
+			userProfile.avatar = '';
+		} else if (!userId) {
+			// Authentication Information
+			userId = localStorage.getItem('bible_is_user_id') || '';
+			isAuthenticated = !!localStorage.getItem('bible_is_user_id') || '';
+			// User Profile
+			userProfile.email = localStorage.getItem('bible_is_user_email') || '';
+			userProfile.nickname = localStorage.getItem('bible_is_user_name') || '';
+			userProfile.name = localStorage.getItem('bible_is_user_nickname');
+			userProfile.userId = userId;
+			// Avatar is a placeholder for when we actually build the rest of that functionality
+			userProfile.avatar = '';
+		}
 
-    // Audio Player
-    initialVolume =
-      cookieData.bible_is_volume === 0 ? 0 : cookieData.bible_is_volume || 1;
-    initialPlaybackRate = cookieData.bible_is_playbackrate || 1;
-  }
+		// Audio Player
+		initialVolume =
+			cookieData.bible_is_volume === 0 ? 0 : cookieData.bible_is_volume || 1;
+		initialPlaybackRate = cookieData.bible_is_playbackrate || 1;
+	}
 
-  const singleBibleUrl = `${process.env.BASE_API_ROUTE}/bibles/${bibleId}?key=${
-    process.env.DBP_API_KEY
-  }&v=4&include_font=false`;
+	const singleBibleUrl = `${process.env.BASE_API_ROUTE}/bibles/${bibleId}?key=${process.env.DBP_API_KEY}&v=4&include_font=false`;
 
-  // Get active bible data
-  const singleBibleRes = await cachedFetch(singleBibleUrl).catch((e) => {
-    console.error('Error in get initial props single bible: ', e.message); // eslint-disable-line no-console
-    if (axios.isAxiosError(e)) {
-      console.error('Error occurred at URL:', e.config.url); // eslint-disable-line no-console
-    }
-    return { data: {} };
-  });
-  const bible = singleBibleRes.data;
+	// Get active bible data
+	const singleBibleRes = await cachedFetch(singleBibleUrl).catch((e) => {
+		console.error('Error in get initial props single bible: ', e.message); // eslint-disable-line no-console
+		if (axios.isAxiosError(e)) {
+			console.error('Error occurred at URL:', e.config.url); // eslint-disable-line no-console
+		}
+		return { data: {} };
+	});
+	const bible = singleBibleRes.data;
 
-  // Acceptable fileset types that the site is capable of ingesting and displaying
-  const setTypes = {
-    audio_drama: true,
-    audio: true,
-    text_plain: true,
-    text_format: true,
-    video_stream: true,
-  };
+	// Acceptable fileset types that the site is capable of ingesting and displaying
+	const setTypes = {
+		audio_drama: true,
+		audio: true,
+		text_plain: true,
+		text_format: true,
+		video_stream: true,
+	};
 
-  const bibleFilesets = bible && bible.filesets ? geFilesetsForBible(bible.filesets) : [];
-  const filesetsWithoutStories = removeStoriesFilesets(bibleFilesets, setTypes);
+	const bibleFilesets = bible?.filesets
+		? geFilesetsForBible(bible.filesets)
+		: [];
+	const filesetsWithoutStories = removeStoriesFilesets(bibleFilesets, setTypes);
 
-  const idsForBookMetadata = filesetsWithoutStories.map((fileset) => ([fileset.type, fileset.id, fileset.size]));
-  const [bookMetaData, bookMetaResponse] = await getBookMetaData({
-    idsForBookMetadata,
-  });
+	const idsForBookMetadata = filesetsWithoutStories.map((fileset) => [
+		fileset.type,
+		fileset.id,
+		fileset.size,
+	]);
+	const [bookMetaData, bookMetaResponse] = await getBookMetaData({
+		idsForBookMetadata,
+	});
 
-  const foundBook = bookMetaData.find(
-    (book) => bookId && book.book_id === bookId.toUpperCase(),
-  );
+	const foundBook = bookMetaData.find(
+		(book) => bookId && book.book_id === bookId.toUpperCase(),
+	);
 
-  const filesets = foundBook ? getValidFilesetsByBook(foundBook, idsForBookMetadata, filesetsWithoutStories) : [];
+	const filesets = foundBook
+		? getValidFilesetsByBook(
+				foundBook,
+				idsForBookMetadata,
+				filesetsWithoutStories,
+				bookMetaResponse,
+		  )
+		: [];
 
-  hasVideo = filesets && filesets.length > 0 && hasFilesetVideo(filesets);
+	hasVideo = filesets && filesets.length > 0 && hasFilesetVideo(filesets);
 
-  // Gets only one of the text_plain filesets
-  const activeFilesetId = filesets
-    ? filesets
-      .filter(
-        (f) => (f.type === FILESET_TYPE_TEXT_PLAIN),
-      )
-      .reduce((a, c) => c.id, '')
-    : '';
+	// Gets only one of the text_plain filesets
+	const activeFilesetId = filesets
+		? filesets
+				.filter((f) => f.type === FILESET_TYPE_TEXT_PLAIN)
+				.reduce((a, c) => c.id, '')
+		: '';
 
-  // Separate filesets by type
-  const plainFilesetIds = filesets.reduce((plainFilesetResult, fileset) => {
-    if (fileset.type === FILESET_TYPE_TEXT_PLAIN) {
-      plainFilesetResult.push(fileset.id);
-    }
-    return plainFilesetResult;
-  }, []);
-  const formattedFilesetIds = filesets.reduce((formattedFilesetResult, fileset) => {
-    if (fileset.type === FILESET_TYPE_TEXT_FORMAT) {
-      formattedFilesetResult.push(fileset.id);
-    }
-    return formattedFilesetResult;
-  }, []);
+	// Separate filesets by type
+	const plainFilesetIds = filesets.reduce((plainFilesetResult, fileset) => {
+		if (fileset.type === FILESET_TYPE_TEXT_PLAIN) {
+			plainFilesetResult.push(fileset.id);
+		}
+		return plainFilesetResult;
+	}, []);
+	const formattedFilesetIds = filesets.reduce(
+		(formattedFilesetResult, fileset) => {
+			if (fileset.type === FILESET_TYPE_TEXT_FORMAT) {
+				formattedFilesetResult.push(fileset.id);
+			}
+			return formattedFilesetResult;
+		},
+		[],
+	);
 
-  if (audioParam) {
-    // If there are any audio filesets with the given type
-    if (filesets.some((set) => set.type === audioParam)) {
-      audioType = audioParam;
-      // Otherwise check for drama first
-    } else if (filesets.some((set) => set.type === FILESET_TYPE_AUDIO_DRAMA)) {
-      audioType = FILESET_TYPE_AUDIO_DRAMA;
-      audioParam = '';
-      // Lastly check for plain audio
-    } else if (filesets.some((set) => set.type === FILESET_TYPE_AUDIO)) {
-      audioType = FILESET_TYPE_AUDIO;
-      audioParam = '';
-    }
-  }
+	if (audioParam) {
+		// If there are any audio filesets with the given type
+		if (filesets.some((set) => set.type === audioParam)) {
+			audioType = audioParam;
+			// Otherwise check for drama first
+		} else if (filesets.some((set) => set.type === FILESET_TYPE_AUDIO_DRAMA)) {
+			audioType = FILESET_TYPE_AUDIO_DRAMA;
+			audioParam = '';
+			// Lastly check for plain audio
+		} else if (filesets.some((set) => set.type === FILESET_TYPE_AUDIO)) {
+			audioType = FILESET_TYPE_AUDIO;
+			audioParam = '';
+		}
+	}
 
-  // Redirect to the new url if conditions are met
-  if (bookMetaData && bookMetaData.length) {
-    const foundChapter =
-      foundBook &&
-      foundBook.chapters.find((c) => chapter && c === parseInt(chapter, 10));
-    // Default book/chapter to matthew 1 to keep it from breaking if there is an error encountered in getFirstChapterReference
-    let bookChapterRoute = 'MAT/1';
-    // Handles getting the book/chapter that follows Jon Stearley's methodology
-    try {
-      bookChapterRoute = getFirstChapterReference(
-        filesets,
-        hasVideo,
-        bookMetaResponse,
-        bookMetaData,
-        audioParam,
-      );
-    } catch (err) {
-      if (process.env.NODE_ENV === 'development') {
-        // eslint-disable-next-line no-console
-        console.error('Error getting initial book', err); // eslint-disble-line no-console
-      }
-    }
+	// Redirect to the new url if conditions are met
+	if (bookMetaData && bookMetaData.length) {
+		const foundChapter =
+			foundBook &&
+			foundBook.chapters.find((c) => chapter && c === parseInt(chapter, 10));
+		// Default book/chapter to matthew 1 to keep it from breaking if there is an error encountered in getFirstChapterReference
+		let bookChapterRoute = 'MAT/1';
+		// Handles getting the book/chapter that follows Jon Stearley's methodology
+		try {
+			bookChapterRoute = getFirstChapterReference(
+				filesets,
+				hasVideo,
+				bookMetaResponse,
+				bookMetaData,
+				audioParam,
+			);
+		} catch (err) {
+			if (process.env.NODE_ENV === 'development') {
+				// eslint-disable-next-line no-console
+				console.error('Error getting initial book', err); // eslint-disble-line no-console
+			}
+		}
 
-    // If the book wasn't found and chapter wasn't found
-    // Go to the first book and first chapter
-    const foundBookId = foundBook && foundBook.book_id;
-    const foundChapterId =
-      foundBook && (foundBook.chapters[0] || foundBook.chapters[0] === 0 || 1);
-    /**
-     * 1. Visit /bible/bibleId
-     */
-    if (!foundBook && (!foundChapter && foundChapter !== 0)) {
-      // Logs the url that will be redirected to
-      if (serverRes) {
-        // If there wasn't a book then we need to redirect to mark for video resources and matthew for other resources
-        serverRes.writeHead(301, {
-          Location: `${req.protocol}://${req.get(
-            'host',
-          )}/bible/${bibleId}/${bookChapterRoute}`,
-        });
-        serverRes.end();
-      } else {
-        Router.push(
-          `${window.location.origin}/bible/${bibleId}/${bookChapterRoute}`,
-        );
-      }
-    } else if (foundBook) {
-      // if the book was found
-      // check for the chapter
-      if (!foundChapter && foundChapter !== 0) {
-        // if the chapter was not found
-        // go to the book and the first chapter for that book
-        if (serverRes) {
-          serverRes.writeHead(301, {
-            Location: `${req.protocol}://${req.get(
-              'host',
-            )}/bible/${bibleId}/${foundBookId}/${foundChapterId}${
-              audioParam ? `?audio_type=${audioParam}` : ''
-            }`,
-          });
-          serverRes.end();
-        } else {
-          Router.push(
-            `${
-              window.location.origin
-            }/bible/${bibleId}/${foundBookId}/${foundChapterId}${
-              audioParam ? `?audio_type=${audioParam}` : ''
-            }`,
-          );
-        }
-      }
-    }
-  }
-  // dont change book or chapter
-  let initData = {
-    plainText: [],
-    formattedText: '',
-    plainTextJson: {},
-    audioPaths: [''],
-  };
-  try {
-    /* eslint-disable no-console */
-    initData = await getinitialChapterData({
-      filesets,
-      bookId,
-      chapter,
-      plainFilesetIds,
-      formattedFilesetIds,
-      audioType,
-    }).catch((err) => {
-      if (process.env.NODE_ENV === 'development') {
-        console.error(
-          `Error caught in get initial chapter data in promise: ${err.message}`,
-        );
-      }
-      return {
-        formattedText: '',
-        plainText: [],
-        plainTextJson: {},
-        audioPaths: [''],
-      };
-    });
-  } catch (err) {
-    if (process.env.NODE_ENV === 'development') {
-      console.error(
-        `Error caught in get initial chapter data by try catch: ${err.message}`,
-      );
-    }
-  }
-  /* eslint-enable no-console */
-  // Get text for chapter
-  const chapterText = initData.plainText;
+		// If the book wasn't found and chapter wasn't found
+		// Go to the first book and first chapter
+		const foundBookId = foundBook && foundBook.book_id;
+		const foundChapterId =
+			foundBook && (foundBook.chapters[0] || foundBook.chapters[0] === 0 || 1);
+		/**
+		 * 1. Visit /bible/bibleId
+		 */
+		if (!foundBook && !foundChapter && foundChapter !== 0) {
+			// Logs the url that will be redirected to
+			if (serverRes) {
+				// If there wasn't a book then we need to redirect to mark for video resources and matthew for other resources
+				serverRes.writeHead(301, {
+					Location: `${req.protocol}://${req.get(
+						'host',
+					)}/bible/${bibleId}/${bookChapterRoute}`,
+				});
+				serverRes.end();
+			} else {
+				const bookRoute = bookChapterRoute.split('/')[0];
+				const chapterRoute = bookChapterRoute.split('/')[1];
+				triggerRedirect.url = `/app?bibleId=${bibleId}&bookId=${bookRoute}&chapter=${chapterRoute}`;
+				triggerRedirect.as = `/bible/${bibleId}/${bookChapterRoute}`;
+			}
+		} else if (foundBook) {
+			// if the book was found
+			// check for the chapter
+			if (!foundChapter && foundChapter !== 0) {
+				// if the chapter was not found
+				// go to the book and the first chapter for that book
+				if (serverRes) {
+					serverRes.writeHead(301, {
+						Location: `${req.protocol}://${req.get(
+							'host',
+						)}/bible/${bibleId}/${foundBookId}/${foundChapterId}${
+							audioParam ? `?audio_type=${audioParam}` : ''
+						}`,
+					});
+					serverRes.end();
+				} else {
+					triggerRedirect.url = `/app?bibleId=${bibleId}&bookId=${foundBookId}&chapter=${foundChapterId}`;
+					triggerRedirect.as = `/bible/${bibleId}/${foundBookId}/${foundChapterId}${
+						audioParam ? `?audio_type=${audioParam}` : ''
+					}`;
+				}
+			}
+		}
+	}
+	// dont change book or chapter
+	let initData = {
+		plainText: [],
+		formattedText: '',
+		plainTextJson: {},
+		audioPaths: [''],
+	};
+	try {
+		/* eslint-disable no-console */
+		initData = await getinitialChapterData({
+			filesets,
+			bookId,
+			chapter,
+			plainFilesetIds,
+			formattedFilesetIds,
+			audioType,
+		}).catch((err) => {
+			if (process.env.NODE_ENV === 'development') {
+				console.error(
+					`Error caught in get initial chapter data in promise: ${err.message}`,
+				);
+			}
+			return {
+				formattedText: '',
+				plainText: [],
+				plainTextJson: {},
+				audioPaths: [''],
+			};
+		});
+	} catch (err) {
+		if (process.env.NODE_ENV === 'development') {
+			console.error(
+				`Error caught in get initial chapter data by try catch: ${err.message}`,
+			);
+		}
+	}
+	/* eslint-enable no-console */
+	// Get text for chapter
+	const chapterText = initData.plainText;
 
-  let activeBook = { chapters: [] };
-  const bookData = bookMetaData.length || !bible ? bookMetaData : bible.books;
+	let activeBook = { chapters: [] };
+	const bookData = bookMetaData.length || !bible ? bookMetaData : bible.books;
 
-  if (bookData) {
-    const urlBook = bookData.find(
-      (book) =>
-        book.book_id && book.book_id.toLowerCase() === bookId.toLowerCase(),
-    );
-    if (urlBook) {
-      activeBook = urlBook;
-    } else {
-      activeBook = bookData[0];
-    }
-  } else {
-    activeBook = undefined;
-  }
-  const availableAudioTypes = [];
+	if (bookData) {
+		const urlBook = bookData.find(
+			(book) =>
+				book.book_id && book.book_id.toLowerCase() === bookId.toLowerCase(),
+		);
+		if (urlBook) {
+			activeBook = urlBook;
+		} else {
+			activeBook = bookData[0];
+		}
+	} else {
+		activeBook = undefined;
+	}
+	const availableAudioTypes = [];
 
-  if (filesets.some((set) => set.type === FILESET_TYPE_AUDIO_DRAMA)) {
-    availableAudioTypes.push(FILESET_TYPE_AUDIO_DRAMA);
-  }
+	if (filesets.some((set) => set.type === FILESET_TYPE_AUDIO_DRAMA)) {
+		availableAudioTypes.push(FILESET_TYPE_AUDIO_DRAMA);
+	}
 
-  if (filesets.some((set) => set.type === FILESET_TYPE_AUDIO)) {
-    availableAudioTypes.push(FILESET_TYPE_AUDIO);
-  }
-  const activeBookName = activeBook ? activeBook.name : '';
-  const testaments = bookData
-    ? bookData.reduce((a, c) => ({ ...a, [c.book_id]: c.testament }), {})
-    : [];
+	if (filesets.some((set) => set.type === FILESET_TYPE_AUDIO)) {
+		availableAudioTypes.push(FILESET_TYPE_AUDIO);
+	}
+	const activeBookName = activeBook ? activeBook.name : '';
+	const testaments = bookData
+		? bookData.reduce((a, c) => ({ ...a, [c.book_id]: c.testament }), {})
+		: [];
 
-  if (context.reduxStore) {
-    if (userProfile.userId && userProfile.email) {
-      context.reduxStore.dispatch({
-        type: 'GET_INITIAL_ROUTE_STATE_PROFILE',
-        profile: {
-          userId: userProfile.userId,
-          userAuthenticated: !!userProfile.userId,
-          userProfile: {
-            email: userProfile.email || '',
-            name: userProfile.name || '',
-            nickname: userProfile.name || '',
-          },
-        },
-      });
-    }
+	if (context.reduxStore) {
+		if (userProfile.userId && userProfile.email) {
+			context.reduxStore.dispatch({
+				type: 'GET_INITIAL_ROUTE_STATE_PROFILE',
+				profile: {
+					userId: userProfile.userId,
+					userAuthenticated: !!userProfile.userId,
+					userProfile: {
+						email: userProfile.email || '',
+						name: userProfile.name || '',
+						nickname: userProfile.name || '',
+					},
+				},
+			});
+		}
 
-    if (cookieData && checkAvailableSettingsDataInCookies(cookieData)) {
-      context.reduxStore.dispatch({
-        type: 'GET_INITIAL_ROUTE_STATE_SETTINGS_FROM_APP',
-        settings: {
-          activeTheme: cookieData.bible_is_theme,
-          activeFontType: cookieData.bible_is_font_family,
-          activeFontSize: cookieData.bible_is_font_size,
-          readersMode: cookieData.bible_is_userSettings_toggleOptions_readersMode_active,
-          justifiedText: cookieData.bible_is_userSettings_toggleOptions_justifiedText_active,
-          redLetter: cookieData.bible_is_userSettings_toggleOptions_justifiedText_active,
-          crossReferences: cookieData.bible_is_userSettings_toggleOptions_crossReferences_active,
-          oneVersePerLine: cookieData.bible_is_userSettings_toggleOptions_oneVersePerLine_active,
-        },
-      });
-    }
+		if (cookieData && checkAvailableSettingsDataInCookies(cookieData)) {
+			context.reduxStore.dispatch({
+				type: 'GET_INITIAL_ROUTE_STATE_SETTINGS_FROM_APP',
+				settings: {
+					activeTheme: cookieData.bible_is_theme,
+					activeFontType: cookieData.bible_is_font_family,
+					activeFontSize: cookieData.bible_is_font_size,
+					readersMode:
+						cookieData.bible_is_userSettings_toggleOptions_readersMode_active,
+					justifiedText:
+						cookieData.bible_is_userSettings_toggleOptions_justifiedText_active,
+					redLetter:
+						cookieData.bible_is_userSettings_toggleOptions_justifiedText_active,
+					crossReferences:
+						cookieData.bible_is_userSettings_toggleOptions_crossReferences_active,
+					oneVersePerLine:
+						cookieData.bible_is_userSettings_toggleOptions_oneVersePerLine_active,
+				},
+			});
+		}
 
-    context.reduxStore.dispatch({
-      type: 'GET_INITIAL_ROUTE_STATE_HOMEPAGE',
-      homepage: {
-        userProfile,
-        activeFilesetId,
-        audioType: audioType || '',
-        availableAudioTypes,
-        loadingAudio: true,
-        hasVideo,
-        chapterText,
-        testaments,
-        // userSettings,
-        formattedSource: initData.formattedText,
-        activeFilesets: filesets,
-        changingVersion: false,
-        books: bookData || [],
-        activeChapter: parseInt(chapter, 10) >= 0 ? parseInt(chapter, 10) : 1,
-        activeBookName,
-        verseNumber: verse,
-        activeTextId: bible.abbr,
-        activeIsoCode: bible.iso || '',
-        defaultLanguageIso: bible.iso || 'eng',
-        activeLanguageName: bible.language || '',
-        activeTextName: bible.vname || bible.name,
-        defaultLanguageName: bible.language || 'English',
-        defaultLanguageCode: bible.language_id || 6414,
-        textDirection: bible.alphabet ? bible.alphabet.direction : 'ltr',
-        activeBookId: bookId.toUpperCase() || '',
-        userId,
-        isIe,
-        userAuthenticated: isAuthenticated || false,
-        isFromServer,
-        match: {
-          params: {
-            bibleId,
-            bookId,
-            chapter,
-            verse,
-            token,
-          },
-        },
-      },
-    });
-  }
+		context.reduxStore.dispatch({
+			type: 'GET_INITIAL_ROUTE_STATE_HOMEPAGE',
+			homepage: {
+				userProfile,
+				activeFilesetId,
+				audioType: audioType || '',
+				availableAudioTypes,
+				loadingAudio: true,
+				hasVideo,
+				videoPlayerOpen: hasVideo,
+				chapterText,
+				testaments,
+				formattedSource: initData.formattedText,
+				activeFilesets: filesets,
+				changingVersion: false,
+				books: bookData || [],
+				activeChapter: parseInt(chapter, 10) >= 0 ? parseInt(chapter, 10) : 1,
+				activeBookName,
+				verseNumber: verse,
+				activeTextId: bible.abbr,
+				activeIsoCode: bible.iso || '',
+				defaultLanguageIso: bible.iso || 'eng',
+				activeLanguageName: bible.language || '',
+				activeTextName: bible.vname || bible.name,
+				defaultLanguageName: bible.language || 'English',
+				defaultLanguageCode: bible.language_id || 6414,
+				textDirection: bible.alphabet ? bible.alphabet.direction : 'ltr',
+				activeBookId: bookId.toUpperCase() || '',
+				userId,
+				isIe,
+				userAuthenticated: isAuthenticated || false,
+				isFromServer,
+				match: {
+					params: {
+						bibleId,
+						bookId,
+						chapter,
+						verse,
+						token,
+					},
+				},
+			},
+		});
+	}
 
-  if (typeof document !== 'undefined') {
-    document.cookie = `bible_is_ref_bible_id=${bibleId}`;
-    document.cookie = `bible_is_ref_book_id=${bookId}`;
-    document.cookie = `bible_is_ref_chapter=${chapter}`;
-    document.cookie = `bible_is_ref_verse=${verse}`;
-  }
-  return {
-    initialVolume,
-    initialPlaybackRate,
-    chapterText,
-    testaments,
-    audioType: audioType || '',
-    formattedText: initData.formattedText,
-    books: bookData || [],
-    activeChapter: parseInt(chapter, 10) >= 0 ? parseInt(chapter, 10) : 1,
-    activeBookName,
-    verseNumber: verse,
-    activeTextId: bible.abbr,
-    activeIsoCode: bible.iso,
-    activeLanguageName: bible.language,
-    textDirection: bible.alphabet ? bible.alphabet.direction : 'ltr',
-    activeFilesets: filesets,
-    defaultLanguageIso: bible.iso || 'eng',
-    defaultLanguageName: bible.language || 'English',
-    defaultLanguageCode: bible.language_id || 6414,
-    activeTextName: bible.vname || bible.name,
-    activeBookId: bookId.toUpperCase(),
-    userProfile,
-    userId: userId || '',
-    isAuthenticated: isAuthenticated || false,
-    isFromServer,
-    isIe,
-    routeLocation,
-    match: {
-      params: {
-        bibleId,
-        bookId,
-        chapter,
-        verse,
-        token,
-      },
-    },
-    fetchedUrls: [],
-  };
+	if (typeof document !== 'undefined') {
+		document.cookie = `bible_is_ref_bible_id=${bibleId}`;
+		document.cookie = `bible_is_ref_book_id=${bookId}`;
+		document.cookie = `bible_is_ref_chapter=${chapter}`;
+		document.cookie = `bible_is_ref_verse=${verse}`;
+	}
+	return {
+		initialVolume,
+		initialPlaybackRate,
+		chapterText,
+		testaments,
+		audioType: audioType || '',
+		formattedText: initData.formattedText,
+		books: bookData || [],
+		activeChapter: parseInt(chapter, 10) >= 0 ? parseInt(chapter, 10) : 1,
+		activeBookName,
+		verseNumber: verse,
+		activeTextId: bible.abbr,
+		activeIsoCode: bible.iso,
+		activeLanguageName: bible.language,
+		textDirection: bible.alphabet ? bible.alphabet.direction : 'ltr',
+		activeFilesets: filesets,
+		defaultLanguageIso: bible.iso || 'eng',
+		defaultLanguageName: bible.language || 'English',
+		defaultLanguageCode: bible.language_id || 6414,
+		activeTextName: bible.vname || bible.name,
+		activeBookId: bookId.toUpperCase(),
+		userProfile,
+		userId: userId || '',
+		isAuthenticated: isAuthenticated || false,
+		isFromServer,
+		isIe,
+		routeLocation,
+		match: {
+			params: {
+				bibleId,
+				bookId,
+				chapter,
+				verse,
+				token,
+			},
+		},
+		fetchedUrls: [],
+		triggerRedirect,
+	};
 };
 
 AppContainer.propTypes = {
-  dispatch: PropTypes.func,
-  match: PropTypes.object,
-  userProfile: PropTypes.object,
-  chapterText: PropTypes.array,
-  fetchedUrls: PropTypes.array,
-  isFromServer: PropTypes.bool,
-  isIe: PropTypes.bool,
-  routeLocation: PropTypes.string,
-  activeBookName: PropTypes.string,
-  formattedText: PropTypes.string,
-  activeChapter: PropTypes.number,
-  initialVolume: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
-  initialPlaybackRate: PropTypes.oneOfType([
-    PropTypes.number,
-    PropTypes.string,
-  ]),
+	dispatch: PropTypes.func,
+	match: PropTypes.object,
+	userProfile: PropTypes.object,
+	chapterText: PropTypes.array,
+	fetchedUrls: PropTypes.array,
+	isFromServer: PropTypes.bool,
+	isIe: PropTypes.bool,
+	routeLocation: PropTypes.string,
+	activeBookName: PropTypes.string,
+	formattedText: PropTypes.string,
+	activeChapter: PropTypes.number,
+	initialVolume: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+	initialPlaybackRate: PropTypes.oneOfType([
+		PropTypes.number,
+		PropTypes.string,
+	]),
+	triggerRedirect: PropTypes.shape({
+		url: PropTypes.string,
+		as: PropTypes.string,
+	}),
 };
 
 export default connect()(AppContainer);

--- a/pages/app.js
+++ b/pages/app.js
@@ -6,13 +6,13 @@
  */
 
 /*
- * Todo: Items that need to be done before production
- * todo: Replace all tabIndex 0 values with what they should actually be
- * todo: Set up a function to init all of the plugins that rely on the browser
- * todo: Update site url to match the live site domain name
- * todo: Use cookies instead of session and local storage for all user settings (involves user approval before it can be utilized)
- * todo: Remove the script for providing feedback
- * */
+* Todo: Items that need to be done before production
+* todo: Replace all tabIndex 0 values with what they should actually be
+* todo: Set up a function to init all of the plugins that rely on the browser
+* todo: Update site url to match the live site domain name
+* todo: Use cookies instead of session and local storage for all user settings (involves user approval before it can be utilized)
+* todo: Remove the script for providing feedback
+* */
 // Needed for redux-saga es6 generator support
 import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
@@ -25,8 +25,8 @@ import HomePage from '../app/containers/HomePage';
 import getinitialChapterData from '../app/utils/getInitialChapterData';
 import getValidFilesetsByBook from '../app/utils/getValidFilesetsByBook';
 import {
-	setChapterTextLoadingState,
-	setUA,
+  setChapterTextLoadingState,
+  setUA,
 } from '../app/containers/HomePage/actions';
 import svg4everybody from '../app/utils/svgPolyfill';
 import parseCookie from '../app/utils/parseCookie';
@@ -40,718 +40,718 @@ import geFilesetsForBible from '../app/utils/geFilesetsForBible';
 import hasFilesetVideo from '../app/utils/hasFilesetVideo';
 import removeStoriesFilesets from '../app/utils/removeStoriesFilesets';
 import {
-	FILESET_TYPE_TEXT_PLAIN,
-	FILESET_TYPE_TEXT_FORMAT,
-	FILESET_TYPE_AUDIO_DRAMA,
-	FILESET_TYPE_AUDIO,
+  FILESET_TYPE_TEXT_PLAIN,
+  FILESET_TYPE_TEXT_FORMAT,
+  FILESET_TYPE_AUDIO_DRAMA,
+  FILESET_TYPE_AUDIO,
 } from '../app/constants/bibleFileset';
 
 function AppContainer(props) {
-	const router = useRouter();
-	const [prevFormattedText, setPrevFormattedText] = useState('');
+  const router = useRouter();
+  const [prevFormattedText, setPrevFormattedText] = useState('');
 
-	/* eslint-disable no-undef */
-	const handleRouteChange = (url) => {
-		/* eslint-enable no-undef */
-		// Pause audio
-		// Start loading spinner for text
-		// Close any open menus
-		// Remove current audio source - (may fix item 1)
-		// TODO: Probably need to get the new highlights here or at least start the process for getting them
-		if (typeof dataLayer !== 'undefined') {
-			try {
-				dataLayer.push({
-					event: 'pageview',
-					page: {
-						path: url,
-						title: url,
-					},
-				});
-			} catch (err) {
-				console.error('Google tag manager did not capture pageview: ', err); // eslint-disable-line no-console
-			}
-		}
-		props.dispatch(setChapterTextLoadingState({ state: true }));
-	};
+  /* eslint-disable no-undef */
+  const handleRouteChange = (url) => {
+    /* eslint-enable no-undef */
+    // Pause audio
+    // Start loading spinner for text
+    // Close any open menus
+    // Remove current audio source - (may fix item 1)
+    // TODO: Probably need to get the new highlights here or at least start the process for getting them
+    if (typeof dataLayer !== 'undefined') {
+      try {
+        dataLayer.push({
+          event: 'pageview',
+          page: {
+            path: url,
+            title: url,
+          },
+        });
+      } catch (err) {
+        console.error('Google tag manager did not capture pageview: ', err); // eslint-disable-line no-console
+      }
+    }
+    props.dispatch(setChapterTextLoadingState({ state: true }));
+  };
 
-	// eslint-disable-line no-undef
-	useEffect(() => {
-		if (
-			localStorage.getItem('reducerVersion') !== REDUX_PERSIST.reducerVersion
-		) {
-			reconcilePersistedState(
-				['settings', 'searchContainer', 'profile'],
-				REDUX_PERSIST.reducerKey,
-			);
-			localStorage.setItem('reducerVersion', REDUX_PERSIST.reducerVersion);
-		}
-		// If the page was served from the server then I need to cache the data for this route
-		if (props.isFromServer) {
-			props.fetchedUrls.forEach((url) => {
-				if (url.data.error || url.data.errors) {
-					overrideCache(url.href, {}, 1);
-				} else {
-					overrideCache(url.href, url.data);
-				}
-			});
-		}
-		// If undefined gets stored in local storage it cannot be parsed so I have to compare strings
-		if (props?.userProfile?.userId) {
-			props.dispatch({
-				type: 'GET_INITIAL_ROUTE_STATE_PROFILE',
-				profile: {
-					userId: props.userProfile.userId,
-					userAuthenticated: !!props.userProfile.userId,
-					userProfile: {
-						email: props.userProfile.email || '',
-						name: props.userProfile.name || '',
-						nickname: props.userProfile.name || '',
-					},
-				},
-			});
-		} else if (sessionStorage?.getItem('bible_is_user_id')) {
-			props.dispatch({
-				type: 'GET_INITIAL_ROUTE_STATE_PROFILE',
-				profile: {
-					userId: sessionStorage.getItem('bible_is_user_id'),
-					userAuthenticated: !!sessionStorage.getItem('bible_is_user_id'),
-					userProfile: {
-						email: sessionStorage.getItem('bible_is_user_email') || '',
-						name: sessionStorage.getItem('bible_is_user_name') || '',
-						nickname: sessionStorage.getItem('bible_is_user_nickname') || '',
-					},
-				},
-			});
-		}
-		const redLetter =
-			!!props.formattedText &&
-			!!(
-				props.formattedText.includes('class="wj"') ||
-				props.formattedText.includes("class='wj'")
-			);
-		props.dispatch({
-			type: 'GET_INITIAL_ROUTE_STATE_SETTINGS',
-			redLetter,
-			crossReferences:
-				!!props.formattedText &&
-				!!(
-					props.formattedText.includes('class="ft"') ||
-					props.formattedText.includes('class="xt"')
-				),
-		});
-		props.dispatch(setChapterTextLoadingState({ state: false }));
+  // eslint-disable-line no-undef
+  useEffect(() => {
+    if (
+      localStorage.getItem('reducerVersion') !== REDUX_PERSIST.reducerVersion
+    ) {
+      reconcilePersistedState(
+        ['settings', 'searchContainer', 'profile'],
+        REDUX_PERSIST.reducerKey,
+      );
+      localStorage.setItem('reducerVersion', REDUX_PERSIST.reducerVersion);
+    }
+    // If the page was served from the server then I need to cache the data for this route
+    if (props.isFromServer) {
+      props.fetchedUrls.forEach((url) => {
+        if (url.data.error || url.data.errors) {
+          overrideCache(url.href, {}, 1);
+        } else {
+          overrideCache(url.href, url.data);
+        }
+      });
+    }
+    // If undefined gets stored in local storage it cannot be parsed so I have to compare strings
+    if (props?.userProfile?.userId) {
+      props.dispatch({
+        type: 'GET_INITIAL_ROUTE_STATE_PROFILE',
+        profile: {
+          userId: props.userProfile.userId,
+          userAuthenticated: !!props.userProfile.userId,
+          userProfile: {
+            email:
+              props.userProfile.email || '',
+            name:
+              props.userProfile.name || '',
+            nickname:
+              props.userProfile.name || '',
+          },
+        },
+      });
+    } else if (sessionStorage?.getItem('bible_is_user_id')) {
+      props.dispatch({
+        type: 'GET_INITIAL_ROUTE_STATE_PROFILE',
+        profile: {
+          userId: sessionStorage.getItem('bible_is_user_id'),
+          userAuthenticated: !!sessionStorage.getItem('bible_is_user_id'),
+          userProfile: {
+            email: sessionStorage.getItem('bible_is_user_email') || '',
+            name: sessionStorage.getItem('bible_is_user_name') || '',
+            nickname: sessionStorage.getItem('bible_is_user_nickname') || '',
+          },
+        },
+      });
+    }
+    const redLetter =
+      !!props.formattedText &&
+      !!(
+        props.formattedText.includes('class="wj"') ||
+        props.formattedText.includes("class='wj'")
+      );
+    props.dispatch({
+      type: 'GET_INITIAL_ROUTE_STATE_SETTINGS',
+      redLetter,
+      crossReferences:
+        !!props.formattedText &&
+        !!(
+          props.formattedText.includes('class="ft"') ||
+          props.formattedText.includes('class="xt"')
+        ),
+    });
+    props.dispatch(setChapterTextLoadingState({ state: false }));
 
-		if (props.isIe) {
-			props.dispatch(setUA());
-			if (
-				typeof svg4everybody === 'function' &&
-				typeof window !== 'undefined'
-			) {
-				svg4everybody();
-			}
-		}
-	}, []);
+    if (props.isIe) {
+      props.dispatch(setUA());
+      if (
+        typeof svg4everybody === 'function' &&
+        typeof window !== 'undefined'
+      ) {
+        svg4everybody();
+      }
+    }
+  }, []);
 
-	useEffect(() => {
-		// Intercept all route changes to ensure that the loading spinner starts
-		router.events.on('routeChangeStart', handleRouteChange);
+  useEffect(() => {
+    // Intercept all route changes to ensure that the loading spinner starts
+    router.events.on('routeChangeStart', handleRouteChange);
 
-		return () => {
-			router.events.off('routeChangeStart', handleRouteChange);
-		};
-	}, [router]);
+    return () => {
+      router.events.off('routeChangeStart', handleRouteChange);
+    };
+  }, [router]);
 
-	useEffect(() => {
-		if (props.formattedText !== prevFormattedText) {
-			const redLetter =
-				!!prevFormattedText &&
-				!!(
-					prevFormattedText.includes('class="wj"') ||
-					prevFormattedText.includes("class='wj'")
-				);
+  useEffect(() => {
+    if (props.formattedText !== prevFormattedText) {
+      const redLetter =
+        !!prevFormattedText &&
+        !!(
+          prevFormattedText.includes('class="wj"') ||
+          prevFormattedText.includes("class='wj'")
+        );
 
-			props.dispatch({
-				type: 'GET_INITIAL_ROUTE_STATE_SETTINGS',
-				redLetter,
-				crossReferences:
-					!!prevFormattedText &&
-					!!(
-						prevFormattedText.includes('class="ft"') ||
-						prevFormattedText.includes('class="xt"')
-					),
-			});
-			setPrevFormattedText(props.formattedText);
-		}
-	}, [props.formattedText]);
+      props.dispatch({
+        type: 'GET_INITIAL_ROUTE_STATE_SETTINGS',
+        redLetter,
+        crossReferences:
+          !!prevFormattedText &&
+          !!(
+            prevFormattedText.includes('class="ft"') ||
+            prevFormattedText.includes('class="xt"')
+          ),
+      });
+      setPrevFormattedText(props.formattedText);
+    }
+  }, [props.formattedText]);
 
-	useEffect(() => {
-		if (props.triggerRedirect.url && props.triggerRedirect.as) {
-			router.push(props.triggerRedirect.url, props.triggerRedirect.as);
-		}
-	}, [props.triggerRedirect.url, props.triggerRedirect.as]);
+  useEffect(() => {
+    if (props.triggerRedirect.url && props.triggerRedirect.as) {
+      router.push(
+        props.triggerRedirect.url,
+        props.triggerRedirect.as,
+      );
+    }
+  }, [props.triggerRedirect.url, props.triggerRedirect.as]);
 
-	const {
-		activeChapter,
-		chapterText,
-		activeBookName,
-		routeLocation,
-		initialPlaybackRate,
-		initialVolume,
-		isIe,
-	} = props;
-	// Defaulting description text to an empty string since no metadata is better than inaccurate metadata
-	const descriptionText =
-		chapterText && chapterText[0] ? `${chapterText[0].verse_text}...` : '';
+  const {
+    activeChapter,
+    chapterText,
+    activeBookName,
+    routeLocation,
+    initialPlaybackRate,
+    initialVolume,
+    isIe,
+  } = props;
+  // Defaulting description text to an empty string since no metadata is better than inaccurate metadata
+  const descriptionText =
+    chapterText && chapterText[0] ? `${chapterText[0].verse_text}...` : '';
 
-	const headTitle = `${activeBookName} ${activeChapter}${
-		props.match?.params?.verse ? `:${props.match.params.verse}` : ''
-	} ${'| Bible.is'}`;
-	return (
-		<div>
-			<Head>
-				<meta name={'description'} content={descriptionText} />
-				<meta
-					property={'og:title'}
-					content={`${activeBookName} ${activeChapter}${
-						props.match?.params?.verse ? `:${props.match.params.verse}` : ''
-					} | Bible.is`}
-				/>
-				<meta
-					property={'og:image'}
-					content={`${process.env.BASE_SITE_URL}/public/icon-310x310.png`}
-				/>
-				<meta property={'og:image:width'} content={310} />
-				<meta property={'og:image:height'} content={310} />
-				<meta
-					property={'og:url'}
-					content={`${process.env.BASE_SITE_URL}/${routeLocation}`}
-				/>
-				<meta property={'og:description'} content={descriptionText} />
-				<meta
-					name={'twitter:title'}
-					content={`${activeBookName} ${activeChapter}`}
-				/>
-				<meta name={'twitter:description'} content={descriptionText} />
-				<title>{headTitle}</title>
-			</Head>
-			<HomePage
-				initialPlaybackRate={initialPlaybackRate}
-				initialVolume={initialVolume}
-				isIe={isIe}
-			/>
-		</div>
-	);
+  const headTitle = `${activeBookName} ${activeChapter}${props.match?.params?.verse
+      ? `:${props.match.params.verse}`
+      : ''
+    } ${'| Bible.is'}`;
+    return (
+      <div>
+        <Head>
+          <meta name={'description'} content={descriptionText} />
+          <meta
+            property={'og:title'}
+            content={`${activeBookName} ${activeChapter}${
+              props.match?.params?.verse
+                ? `:${props.match.params.verse}`
+                : ''
+            } | Bible.is`}
+          />
+          <meta
+            property={'og:image'}
+            content={`${process.env.BASE_SITE_URL}/public/icon-310x310.png`}
+          />
+          <meta property={'og:image:width'} content={310} />
+          <meta property={'og:image:height'} content={310} />
+          <meta
+            property={'og:url'}
+            content={`${process.env.BASE_SITE_URL}/${routeLocation}`}
+          />
+          <meta property={'og:description'} content={descriptionText} />
+          <meta
+            name={'twitter:title'}
+            content={`${activeBookName} ${activeChapter}`}
+          />
+          <meta name={'twitter:description'} content={descriptionText} />
+          <title>
+            {headTitle}
+          </title>
+        </Head>
+        <HomePage
+          initialPlaybackRate={initialPlaybackRate}
+          initialVolume={initialVolume}
+          isIe={isIe}
+        />
+      </div>
+    );
 }
 
 AppContainer.displayName = 'Main app';
 
 AppContainer.getInitialProps = async (context) => {
-	const { req, res: serverRes } = context;
-	const routeLocation = context.asPath;
-	const {
-		bookId = '',
-		chapter: chapterParam,
-		bibleId = 'ENGESV',
-		verse,
-		token,
-		userId: reqUserId,
-		userEmail = '',
-		userName = '',
-	} = context.query;
-	const userProfile = {
-		userId: reqUserId,
-		email: userEmail,
-		name: userName,
-		nickname: userName,
-	};
-	const tempChapter =
-		typeof chapterParam === 'string' && chapterParam.split('?')[0];
-	const chapter = tempChapter || chapter;
-	// Using let here because the cookie data can come from the server or the client
-	let audioParam = req && req.query.audio_type;
-	let userId = reqUserId || '';
-	let hasVideo = false;
-	let isFromServer = true;
-	let isAuthenticated = false;
-	let initialVolume = 1;
-	let initialPlaybackRate = 1;
-	let isIe = false;
-	let audioType = '';
-	const triggerRedirect = {
-		url: null,
-		as: null,
-	};
+  const { req, res: serverRes } = context;
+  const routeLocation = context.asPath;
+  const {
+    bookId = '',
+    chapter: chapterParam,
+    bibleId = 'ENGESV',
+    verse,
+    token,
+    userId: reqUserId,
+    userEmail = '',
+    userName = '',
+  } = context.query;
+  const userProfile = {
+    userId: reqUserId,
+    email: userEmail,
+    name: userName,
+    nickname: userName,
+  };
+  const tempChapter =
+    typeof chapterParam === 'string' && chapterParam.split('?')[0];
+  const chapter = tempChapter || chapter;
+  // Using let here because the cookie data can come from the server or the client
+  let audioParam = req && req.query.audio_type;
+  let userId = reqUserId || '';
+  let hasVideo = false;
+  let isFromServer = true;
+  let isAuthenticated = false;
+  let initialVolume = 1;
+  let initialPlaybackRate = 1;
+  let isIe = false;
+  let audioType = '';
+  const triggerRedirect = {
+    url: null,
+    as: null,
+  };
 
-	if (req?.query.audio_type) {
-		audioParam = req.query.audio_type;
-	} else if (!req) {
-		audioParam = context.query.audio_type;
-	}
+  if (req?.query.audio_type) {
+    audioParam = req.query.audio_type;
+  } else if (!req) {
+    audioParam = context.query.audio_type;
+  }
 
-	if (req?.headers) {
-		isIe = isUserAgentInternetExplorer(req.headers['user-agent']);
-	}
+  if (req?.headers) {
+    isIe = isUserAgentInternetExplorer(req.headers['user-agent']);
+  }
 
-	let cookieData = null;
+  let cookieData = null;
 
-	if (req?.headers.cookie) {
-		// Get all cookies that the page needs
-		cookieData = parseCookie(req.headers.cookie);
+  if (req?.headers.cookie) {
+    // Get all cookies that the page needs
+    cookieData = parseCookie(req.headers.cookie);
 
-		if (cookieData.bible_is_audio_type) {
-			audioType = cookieData.bible_is_audio_type;
-		}
+    if (cookieData.bible_is_audio_type) {
+      audioType = cookieData.bible_is_audio_type;
+    }
 
-		if (userId) {
-			// Authentication Information
-			isAuthenticated = !!userId;
-			// User Profile
-			userProfile.email = userEmail;
-			userProfile.nickname = userName;
-			userProfile.name = userName;
-			userProfile.userId = userId;
-			// Avatar is a placeholder for when we actually build the rest of that functionality
-			userProfile.avatar = '';
-		} else if (!userId) {
-			// Authentication Information
-			userId = cookieData.bible_is_user_id || '';
-			isAuthenticated = !!cookieData.bible_is_user_id;
-			// User Profile
-			userProfile.email = cookieData.bible_is_email || '';
-			userProfile.nickname = cookieData.bible_is_name || '';
-			userProfile.name = cookieData.bible_is_name;
-			// Avatar is a placeholder for when we actually build the rest of that functionality
-			userProfile.avatar = '';
-		}
+    if (userId) {
+      // Authentication Information
+      isAuthenticated = !!userId;
+      // User Profile
+      userProfile.email = userEmail;
+      userProfile.nickname = userName;
+      userProfile.name = userName;
+      userProfile.userId = userId;
+      // Avatar is a placeholder for when we actually build the rest of that functionality
+      userProfile.avatar = '';
+    } else if (!userId) {
+      // Authentication Information
+      userId = cookieData.bible_is_user_id || '';
+      isAuthenticated = !!cookieData.bible_is_user_id;
+      // User Profile
+      userProfile.email = cookieData.bible_is_email || '';
+      userProfile.nickname = cookieData.bible_is_name || '';
+      userProfile.name = cookieData.bible_is_name;
+      // Avatar is a placeholder for when we actually build the rest of that functionality
+      userProfile.avatar = '';
+    }
 
-		// Audio Player
-		initialVolume =
-			cookieData.bible_is_volume === 0 ? 0 : cookieData.bible_is_volume || 1;
-		initialPlaybackRate = cookieData.bible_is_playbackrate || 1;
+    // Audio Player
+    initialVolume =
+      cookieData.bible_is_volume === 0 ? 0 : cookieData.bible_is_volume || 1;
+    initialPlaybackRate = cookieData.bible_is_playbackrate || 1;
 
-		// Handle oauth code if there is one
-		if (cookieData.bible_is_cb_code && cookieData.bible_is_provider) {
-			await fetch(
-				`${process.env.BASE_API_ROUTE}/login/${cookieData.bible_is_provider}/callback?v=4&project_id=${process.env.NOTES_PROJECT_ID}&key=${process.env.DBP_API_KEY}&alt_url=true&code=${cookieData.bible_is_cb_code}`,
-			).then((body) => body.data);
-		}
+    // Handle oauth code if there is one
+    if (cookieData.bible_is_cb_code && cookieData.bible_is_provider) {
+      await fetch(
+        `${process.env.BASE_API_ROUTE}/login/${
+          cookieData.bible_is_provider
+        }/callback?v=4&project_id=${process.env.NOTES_PROJECT_ID}&key=${
+          process.env.DBP_API_KEY
+        }&alt_url=true&code=${cookieData.bible_is_cb_code}`,
+      ).then((body) => body.data);
+    }
 
-		isFromServer = false;
-	} else if (typeof document !== 'undefined' && document.cookie) {
-		cookieData = parseCookie(document.cookie);
-		if (cookieData.bible_is_audio_type) {
-			audioType = cookieData.bible_is_audio_type;
-		}
+    isFromServer = false;
+  } else if (typeof document !== 'undefined' && document.cookie) {
+    cookieData = parseCookie(document.cookie);
+    if (cookieData.bible_is_audio_type) {
+      audioType = cookieData.bible_is_audio_type;
+    }
 
-		if (userId) {
-			// Authentication Information
-			isAuthenticated = !!userId;
-			// User Profile
-			userProfile.email = userEmail;
-			userProfile.nickname = userName;
-			userProfile.name = userName;
-			userProfile.userId = userId;
-			// Avatar is a placeholder for when we actually build the rest of that functionality
-			userProfile.avatar = '';
-		} else if (!userId) {
-			// Authentication Information
-			userId = localStorage.getItem('bible_is_user_id') || '';
-			isAuthenticated = !!localStorage.getItem('bible_is_user_id') || '';
-			// User Profile
-			userProfile.email = localStorage.getItem('bible_is_user_email') || '';
-			userProfile.nickname = localStorage.getItem('bible_is_user_name') || '';
-			userProfile.name = localStorage.getItem('bible_is_user_nickname');
-			userProfile.userId = userId;
-			// Avatar is a placeholder for when we actually build the rest of that functionality
-			userProfile.avatar = '';
-		}
+    if (userId) {
+      // Authentication Information
+      isAuthenticated = !!userId;
+      // User Profile
+      userProfile.email = userEmail;
+      userProfile.nickname = userName;
+      userProfile.name = userName;
+      userProfile.userId = userId;
+      // Avatar is a placeholder for when we actually build the rest of that functionality
+      userProfile.avatar = '';
+    } else if (!userId) {
+      // Authentication Information
+      userId = localStorage.getItem('bible_is_user_id') || '';
+      isAuthenticated = !!localStorage.getItem('bible_is_user_id') || '';
+      // User Profile
+      userProfile.email = localStorage.getItem('bible_is_user_email') || '';
+      userProfile.nickname = localStorage.getItem('bible_is_user_name') || '';
+      userProfile.name = localStorage.getItem('bible_is_user_nickname');
+      userProfile.userId = userId;
+      // Avatar is a placeholder for when we actually build the rest of that functionality
+      userProfile.avatar = '';
+    }
 
-		// Audio Player
-		initialVolume =
-			cookieData.bible_is_volume === 0 ? 0 : cookieData.bible_is_volume || 1;
-		initialPlaybackRate = cookieData.bible_is_playbackrate || 1;
-	}
+    // Audio Player
+    initialVolume =
+      cookieData.bible_is_volume === 0 ? 0 : cookieData.bible_is_volume || 1;
+    initialPlaybackRate = cookieData.bible_is_playbackrate || 1;
+  }
 
-	const singleBibleUrl = `${process.env.BASE_API_ROUTE}/bibles/${bibleId}?key=${process.env.DBP_API_KEY}&v=4&include_font=false`;
+  const singleBibleUrl = `${process.env.BASE_API_ROUTE}/bibles/${bibleId}?key=${
+    process.env.DBP_API_KEY
+  }&v=4&include_font=false`;
 
-	// Get active bible data
-	const singleBibleRes = await cachedFetch(singleBibleUrl).catch((e) => {
-		console.error('Error in get initial props single bible: ', e.message); // eslint-disable-line no-console
-		if (axios.isAxiosError(e)) {
-			console.error('Error occurred at URL:', e.config.url); // eslint-disable-line no-console
-		}
-		return { data: {} };
-	});
-	const bible = singleBibleRes.data;
+  // Get active bible data
+  const singleBibleRes = await cachedFetch(singleBibleUrl).catch((e) => {
+    console.error('Error in get initial props single bible: ', e.message); // eslint-disable-line no-console
+    if (axios.isAxiosError(e)) {
+      console.error('Error occurred at URL:', e.config.url); // eslint-disable-line no-console
+    }
+    return { data: {} };
+  });
+  const bible = singleBibleRes.data;
 
-	// Acceptable fileset types that the site is capable of ingesting and displaying
-	const setTypes = {
-		audio_drama: true,
-		audio: true,
-		text_plain: true,
-		text_format: true,
-		video_stream: true,
-	};
+  // Acceptable fileset types that the site is capable of ingesting and displaying
+  const setTypes = {
+    audio_drama: true,
+    audio: true,
+    text_plain: true,
+    text_format: true,
+    video_stream: true,
+  };
 
-	const bibleFilesets = bible?.filesets
-		? geFilesetsForBible(bible.filesets)
-		: [];
-	const filesetsWithoutStories = removeStoriesFilesets(bibleFilesets, setTypes);
+  const bibleFilesets = bible?.filesets ? geFilesetsForBible(bible.filesets) : [];
+  const filesetsWithoutStories = removeStoriesFilesets(bibleFilesets, setTypes);
 
-	const idsForBookMetadata = filesetsWithoutStories.map((fileset) => [
-		fileset.type,
-		fileset.id,
-		fileset.size,
-	]);
-	const [bookMetaData, bookMetaResponse] = await getBookMetaData({
-		idsForBookMetadata,
-	});
+  const idsForBookMetadata = filesetsWithoutStories.map((fileset) => ([fileset.type, fileset.id, fileset.size]));
+  const [bookMetaData, bookMetaResponse] = await getBookMetaData({
+    idsForBookMetadata,
+  });
 
-	const foundBook = bookMetaData.find(
-		(book) => bookId && book.book_id === bookId.toUpperCase(),
-	);
+  const foundBook = bookMetaData.find(
+    (book) => bookId && book.book_id === bookId.toUpperCase(),
+  );
 
-	const filesets = foundBook
-		? getValidFilesetsByBook(
-				foundBook,
-				idsForBookMetadata,
-				filesetsWithoutStories,
-				bookMetaResponse,
-		  )
-		: [];
+  const filesets = foundBook
+    ? getValidFilesetsByBook(foundBook, idsForBookMetadata, filesetsWithoutStories, bookMetaResponse)
+    : [];
 
-	hasVideo = filesets && filesets.length > 0 && hasFilesetVideo(filesets);
+  hasVideo = filesets && filesets.length > 0 && hasFilesetVideo(filesets);
 
-	// Gets only one of the text_plain filesets
-	const activeFilesetId = filesets
-		? filesets
-				.filter((f) => f.type === FILESET_TYPE_TEXT_PLAIN)
-				.reduce((a, c) => c.id, '')
-		: '';
+  // Gets only one of the text_plain filesets
+  const activeFilesetId = filesets
+    ? filesets
+      .filter(
+        (f) => (f.type === FILESET_TYPE_TEXT_PLAIN),
+      )
+      .reduce((a, c) => c.id, '')
+    : '';
 
-	// Separate filesets by type
-	const plainFilesetIds = filesets.reduce((plainFilesetResult, fileset) => {
-		if (fileset.type === FILESET_TYPE_TEXT_PLAIN) {
-			plainFilesetResult.push(fileset.id);
-		}
-		return plainFilesetResult;
-	}, []);
-	const formattedFilesetIds = filesets.reduce(
-		(formattedFilesetResult, fileset) => {
-			if (fileset.type === FILESET_TYPE_TEXT_FORMAT) {
-				formattedFilesetResult.push(fileset.id);
-			}
-			return formattedFilesetResult;
-		},
-		[],
-	);
+  // Separate filesets by type
+  const plainFilesetIds = filesets.reduce((plainFilesetResult, fileset) => {
+    if (fileset.type === FILESET_TYPE_TEXT_PLAIN) {
+      plainFilesetResult.push(fileset.id);
+    }
+    return plainFilesetResult;
+  }, []);
+  const formattedFilesetIds = filesets.reduce((formattedFilesetResult, fileset) => {
+    if (fileset.type === FILESET_TYPE_TEXT_FORMAT) {
+      formattedFilesetResult.push(fileset.id);
+    }
+    return formattedFilesetResult;
+  }, []);
 
-	if (audioParam) {
-		// If there are any audio filesets with the given type
-		if (filesets.some((set) => set.type === audioParam)) {
-			audioType = audioParam;
-			// Otherwise check for drama first
-		} else if (filesets.some((set) => set.type === FILESET_TYPE_AUDIO_DRAMA)) {
-			audioType = FILESET_TYPE_AUDIO_DRAMA;
-			audioParam = '';
-			// Lastly check for plain audio
-		} else if (filesets.some((set) => set.type === FILESET_TYPE_AUDIO)) {
-			audioType = FILESET_TYPE_AUDIO;
-			audioParam = '';
-		}
-	}
+  if (audioParam) {
+    // If there are any audio filesets with the given type
+    if (filesets.some((set) => set.type === audioParam)) {
+      audioType = audioParam;
+      // Otherwise check for drama first
+    } else if (filesets.some((set) => set.type === FILESET_TYPE_AUDIO_DRAMA)) {
+      audioType = FILESET_TYPE_AUDIO_DRAMA;
+      audioParam = '';
+      // Lastly check for plain audio
+    } else if (filesets.some((set) => set.type === FILESET_TYPE_AUDIO)) {
+      audioType = FILESET_TYPE_AUDIO;
+      audioParam = '';
+    }
+  }
 
-	// Redirect to the new url if conditions are met
-	if (bookMetaData && bookMetaData.length) {
-		const foundChapter =
-			foundBook &&
-			foundBook.chapters.find((c) => chapter && c === parseInt(chapter, 10));
-		// Default book/chapter to matthew 1 to keep it from breaking if there is an error encountered in getFirstChapterReference
-		let bookChapterRoute = 'MAT/1';
-		// Handles getting the book/chapter that follows Jon Stearley's methodology
-		try {
-			bookChapterRoute = getFirstChapterReference(
-				filesets,
-				hasVideo,
-				bookMetaResponse,
-				bookMetaData,
-				audioParam,
-			);
-		} catch (err) {
-			if (process.env.NODE_ENV === 'development') {
-				// eslint-disable-next-line no-console
-				console.error('Error getting initial book', err); // eslint-disble-line no-console
-			}
-		}
+  // Redirect to the new url if conditions are met
+  if (bookMetaData && bookMetaData.length) {
+    const foundChapter =
+      foundBook &&
+      foundBook.chapters.find((c) => chapter && c === parseInt(chapter, 10));
+    // Default book/chapter to matthew 1 to keep it from breaking if there is an error encountered in getFirstChapterReference
+    let bookChapterRoute = 'MAT/1';
+    // Handles getting the book/chapter that follows Jon Stearley's methodology
+    try {
+      bookChapterRoute = getFirstChapterReference(
+        filesets,
+        hasVideo,
+        bookMetaResponse,
+        bookMetaData,
+        audioParam,
+      );
+    } catch (err) {
+      if (process.env.NODE_ENV === 'development') {
+        // eslint-disable-next-line no-console
+        console.error('Error getting initial book', err); // eslint-disble-line no-console
+      }
+    }
 
-		// If the book wasn't found and chapter wasn't found
-		// Go to the first book and first chapter
-		const foundBookId = foundBook && foundBook.book_id;
-		const foundChapterId =
-			foundBook && (foundBook.chapters[0] || foundBook.chapters[0] === 0 || 1);
-		/**
-		 * 1. Visit /bible/bibleId
-		 */
-		if (!foundBook && !foundChapter && foundChapter !== 0) {
-			// Logs the url that will be redirected to
-			if (serverRes) {
-				// If there wasn't a book then we need to redirect to mark for video resources and matthew for other resources
-				serverRes.writeHead(301, {
-					Location: `${req.protocol}://${req.get(
-						'host',
-					)}/bible/${bibleId}/${bookChapterRoute}`,
-				});
-				serverRes.end();
-			} else {
-				const bookRoute = bookChapterRoute.split('/')[0];
-				const chapterRoute = bookChapterRoute.split('/')[1];
-				triggerRedirect.url = `/app?bibleId=${bibleId}&bookId=${bookRoute}&chapter=${chapterRoute}`;
-				triggerRedirect.as = `/bible/${bibleId}/${bookChapterRoute}`;
-			}
-		} else if (foundBook) {
-			// if the book was found
-			// check for the chapter
-			if (!foundChapter && foundChapter !== 0) {
-				// if the chapter was not found
-				// go to the book and the first chapter for that book
-				if (serverRes) {
-					serverRes.writeHead(301, {
-						Location: `${req.protocol}://${req.get(
-							'host',
-						)}/bible/${bibleId}/${foundBookId}/${foundChapterId}${
-							audioParam ? `?audio_type=${audioParam}` : ''
-						}`,
-					});
-					serverRes.end();
-				} else {
-					triggerRedirect.url = `/app?bibleId=${bibleId}&bookId=${foundBookId}&chapter=${foundChapterId}`;
-					triggerRedirect.as = `/bible/${bibleId}/${foundBookId}/${foundChapterId}${
-						audioParam ? `?audio_type=${audioParam}` : ''
-					}`;
-				}
-			}
-		}
-	}
-	// dont change book or chapter
-	let initData = {
-		plainText: [],
-		formattedText: '',
-		plainTextJson: {},
-		audioPaths: [''],
-	};
-	try {
-		/* eslint-disable no-console */
-		initData = await getinitialChapterData({
-			filesets,
-			bookId,
-			chapter,
-			plainFilesetIds,
-			formattedFilesetIds,
-			audioType,
-		}).catch((err) => {
-			if (process.env.NODE_ENV === 'development') {
-				console.error(
-					`Error caught in get initial chapter data in promise: ${err.message}`,
-				);
-			}
-			return {
-				formattedText: '',
-				plainText: [],
-				plainTextJson: {},
-				audioPaths: [''],
-			};
-		});
-	} catch (err) {
-		if (process.env.NODE_ENV === 'development') {
-			console.error(
-				`Error caught in get initial chapter data by try catch: ${err.message}`,
-			);
-		}
-	}
-	/* eslint-enable no-console */
-	// Get text for chapter
-	const chapterText = initData.plainText;
+    // If the book wasn't found and chapter wasn't found
+    // Go to the first book and first chapter
+    const foundBookId = foundBook && foundBook.book_id;
+    const foundChapterId =
+      foundBook && (foundBook.chapters[0] || foundBook.chapters[0] === 0 || 1);
+    /**
+     * 1. Visit /bible/bibleId
+     */
+    if (!foundBook && (!foundChapter && foundChapter !== 0)) {
+      // Logs the url that will be redirected to
+      if (serverRes) {
+        // If there wasn't a book then we need to redirect to mark for video resources and matthew for other resources
+        serverRes.writeHead(301, {
+          Location: `${req.protocol}://${req.get(
+            'host',
+          )}/bible/${bibleId}/${bookChapterRoute}`,
+        });
+        serverRes.end();
+      } else {
+        const bookRoute = bookChapterRoute.split('/')[0];
+        const chapterRoute = bookChapterRoute.split('/')[1];
+        triggerRedirect.url = `/app?bibleId=${bibleId}&bookId=${bookRoute}&chapter=${chapterRoute}`;
+        triggerRedirect.as = `/bible/${bibleId}/${bookChapterRoute}`;
+      }
+    } else if (foundBook) {
+      // if the book was found
+      // check for the chapter
+      if (!foundChapter && foundChapter !== 0) {
+        // if the chapter was not found
+        // go to the book and the first chapter for that book
+        if (serverRes) {
+          serverRes.writeHead(301, {
+            Location: `${req.protocol}://${req.get(
+              'host',
+            )}/bible/${bibleId}/${foundBookId}/${foundChapterId}${
+              audioParam ? `?audio_type=${audioParam}` : ''
+            }`,
+          });
+          serverRes.end();
+        } else {
+          triggerRedirect.url = `/app?bibleId=${bibleId}&bookId=${foundBookId}&chapter=${foundChapterId}`;
+          triggerRedirect.as = `/bible/${bibleId}/${foundBookId}/${foundChapterId}${
+            audioParam ? `?audio_type=${audioParam}` : ''
+          }`;
+        }
+      }
+    }
+  }
+  // dont change book or chapter
+  let initData = {
+    plainText: [],
+    formattedText: '',
+    plainTextJson: {},
+    audioPaths: [''],
+  };
+  try {
+    /* eslint-disable no-console */
+    initData = await getinitialChapterData({
+      filesets,
+      bookId,
+      chapter,
+      plainFilesetIds,
+      formattedFilesetIds,
+      audioType,
+    }).catch((err) => {
+      if (process.env.NODE_ENV === 'development') {
+        console.error(
+          `Error caught in get initial chapter data in promise: ${err.message}`,
+        );
+      }
+      return {
+        formattedText: '',
+        plainText: [],
+        plainTextJson: {},
+        audioPaths: [''],
+      };
+    });
+  } catch (err) {
+    if (process.env.NODE_ENV === 'development') {
+      console.error(
+        `Error caught in get initial chapter data by try catch: ${err.message}`,
+      );
+    }
+  }
+  /* eslint-enable no-console */
+  // Get text for chapter
+  const chapterText = initData.plainText;
 
-	let activeBook = { chapters: [] };
-	const bookData = bookMetaData.length || !bible ? bookMetaData : bible.books;
+  let activeBook = { chapters: [] };
+  const bookData = bookMetaData.length || !bible ? bookMetaData : bible.books;
 
-	if (bookData) {
-		const urlBook = bookData.find(
-			(book) =>
-				book.book_id && book.book_id.toLowerCase() === bookId.toLowerCase(),
-		);
-		if (urlBook) {
-			activeBook = urlBook;
-		} else {
-			activeBook = bookData[0];
-		}
-	} else {
-		activeBook = undefined;
-	}
-	const availableAudioTypes = [];
+  if (bookData) {
+    const urlBook = bookData.find(
+      (book) =>
+        book.book_id && book.book_id.toLowerCase() === bookId.toLowerCase(),
+    );
+    if (urlBook) {
+      activeBook = urlBook;
+    } else {
+      activeBook = bookData[0];
+    }
+  } else {
+    activeBook = undefined;
+  }
+  const availableAudioTypes = [];
 
-	if (filesets.some((set) => set.type === FILESET_TYPE_AUDIO_DRAMA)) {
-		availableAudioTypes.push(FILESET_TYPE_AUDIO_DRAMA);
-	}
+  if (filesets.some((set) => set.type === FILESET_TYPE_AUDIO_DRAMA)) {
+    availableAudioTypes.push(FILESET_TYPE_AUDIO_DRAMA);
+  }
 
-	if (filesets.some((set) => set.type === FILESET_TYPE_AUDIO)) {
-		availableAudioTypes.push(FILESET_TYPE_AUDIO);
-	}
-	const activeBookName = activeBook ? activeBook.name : '';
-	const testaments = bookData
-		? bookData.reduce((a, c) => ({ ...a, [c.book_id]: c.testament }), {})
-		: [];
+  if (filesets.some((set) => set.type === FILESET_TYPE_AUDIO)) {
+    availableAudioTypes.push(FILESET_TYPE_AUDIO);
+  }
+  const activeBookName = activeBook ? activeBook.name : '';
+  const testaments = bookData
+    ? bookData.reduce((a, c) => ({ ...a, [c.book_id]: c.testament }), {})
+    : [];
 
-	if (context.reduxStore) {
-		if (userProfile.userId && userProfile.email) {
-			context.reduxStore.dispatch({
-				type: 'GET_INITIAL_ROUTE_STATE_PROFILE',
-				profile: {
-					userId: userProfile.userId,
-					userAuthenticated: !!userProfile.userId,
-					userProfile: {
-						email: userProfile.email || '',
-						name: userProfile.name || '',
-						nickname: userProfile.name || '',
-					},
-				},
-			});
-		}
+  if (context.reduxStore) {
+    if (userProfile.userId && userProfile.email) {
+      context.reduxStore.dispatch({
+        type: 'GET_INITIAL_ROUTE_STATE_PROFILE',
+        profile: {
+          userId: userProfile.userId,
+          userAuthenticated: !!userProfile.userId,
+          userProfile: {
+            email: userProfile.email || '',
+            name: userProfile.name || '',
+            nickname: userProfile.name || '',
+          },
+        },
+      });
+    }
 
-		if (cookieData && checkAvailableSettingsDataInCookies(cookieData)) {
-			context.reduxStore.dispatch({
-				type: 'GET_INITIAL_ROUTE_STATE_SETTINGS_FROM_APP',
-				settings: {
-					activeTheme: cookieData.bible_is_theme,
-					activeFontType: cookieData.bible_is_font_family,
-					activeFontSize: cookieData.bible_is_font_size,
-					readersMode:
-						cookieData.bible_is_userSettings_toggleOptions_readersMode_active,
-					justifiedText:
-						cookieData.bible_is_userSettings_toggleOptions_justifiedText_active,
-					redLetter:
-						cookieData.bible_is_userSettings_toggleOptions_justifiedText_active,
-					crossReferences:
-						cookieData.bible_is_userSettings_toggleOptions_crossReferences_active,
-					oneVersePerLine:
-						cookieData.bible_is_userSettings_toggleOptions_oneVersePerLine_active,
-				},
-			});
-		}
+    if (cookieData && checkAvailableSettingsDataInCookies(cookieData)) {
+      context.reduxStore.dispatch({
+        type: 'GET_INITIAL_ROUTE_STATE_SETTINGS_FROM_APP',
+        settings: {
+          activeTheme: cookieData.bible_is_theme,
+          activeFontType: cookieData.bible_is_font_family,
+          activeFontSize: cookieData.bible_is_font_size,
+          readersMode: cookieData.bible_is_userSettings_toggleOptions_readersMode_active,
+          justifiedText: cookieData.bible_is_userSettings_toggleOptions_justifiedText_active,
+          redLetter: cookieData.bible_is_userSettings_toggleOptions_justifiedText_active,
+          crossReferences: cookieData.bible_is_userSettings_toggleOptions_crossReferences_active,
+          oneVersePerLine: cookieData.bible_is_userSettings_toggleOptions_oneVersePerLine_active,
+        },
+      });
+    }
 
-		context.reduxStore.dispatch({
-			type: 'GET_INITIAL_ROUTE_STATE_HOMEPAGE',
-			homepage: {
-				userProfile,
-				activeFilesetId,
-				audioType: audioType || '',
-				availableAudioTypes,
-				loadingAudio: true,
-				hasVideo,
-				videoPlayerOpen: hasVideo,
-				chapterText,
-				testaments,
-				formattedSource: initData.formattedText,
-				activeFilesets: filesets,
-				changingVersion: false,
-				books: bookData || [],
-				activeChapter: parseInt(chapter, 10) >= 0 ? parseInt(chapter, 10) : 1,
-				activeBookName,
-				verseNumber: verse,
-				activeTextId: bible.abbr,
-				activeIsoCode: bible.iso || '',
-				defaultLanguageIso: bible.iso || 'eng',
-				activeLanguageName: bible.language || '',
-				activeTextName: bible.vname || bible.name,
-				defaultLanguageName: bible.language || 'English',
-				defaultLanguageCode: bible.language_id || 6414,
-				textDirection: bible.alphabet ? bible.alphabet.direction : 'ltr',
-				activeBookId: bookId.toUpperCase() || '',
-				userId,
-				isIe,
-				userAuthenticated: isAuthenticated || false,
-				isFromServer,
-				match: {
-					params: {
-						bibleId,
-						bookId,
-						chapter,
-						verse,
-						token,
-					},
-				},
-			},
-		});
-	}
+    context.reduxStore.dispatch({
+      type: 'GET_INITIAL_ROUTE_STATE_HOMEPAGE',
+      homepage: {
+        userProfile,
+        activeFilesetId,
+        audioType: audioType || '',
+        availableAudioTypes,
+        loadingAudio: true,
+        hasVideo,
+        videoPlayerOpen: hasVideo,
+        chapterText,
+        testaments,
+        formattedSource: initData.formattedText,
+        activeFilesets: filesets,
+        changingVersion: false,
+        books: bookData || [],
+        activeChapter: parseInt(chapter, 10) >= 0 ? parseInt(chapter, 10) : 1,
+        activeBookName,
+        verseNumber: verse,
+        activeTextId: bible.abbr,
+        activeIsoCode: bible.iso || '',
+        defaultLanguageIso: bible.iso || 'eng',
+        activeLanguageName: bible.language || '',
+        activeTextName: bible.vname || bible.name,
+        defaultLanguageName: bible.language || 'English',
+        defaultLanguageCode: bible.language_id || 6414,
+        textDirection: bible.alphabet ? bible.alphabet.direction : 'ltr',
+        activeBookId: bookId.toUpperCase() || '',
+        userId,
+        isIe,
+        userAuthenticated: isAuthenticated || false,
+        isFromServer,
+        match: {
+          params: {
+            bibleId,
+            bookId,
+            chapter,
+            verse,
+            token,
+          },
+        },
+      },
+    });
+  }
 
-	if (typeof document !== 'undefined') {
-		document.cookie = `bible_is_ref_bible_id=${bibleId}`;
-		document.cookie = `bible_is_ref_book_id=${bookId}`;
-		document.cookie = `bible_is_ref_chapter=${chapter}`;
-		document.cookie = `bible_is_ref_verse=${verse}`;
-	}
-	return {
-		initialVolume,
-		initialPlaybackRate,
-		chapterText,
-		testaments,
-		audioType: audioType || '',
-		formattedText: initData.formattedText,
-		books: bookData || [],
-		activeChapter: parseInt(chapter, 10) >= 0 ? parseInt(chapter, 10) : 1,
-		activeBookName,
-		verseNumber: verse,
-		activeTextId: bible.abbr,
-		activeIsoCode: bible.iso,
-		activeLanguageName: bible.language,
-		textDirection: bible.alphabet ? bible.alphabet.direction : 'ltr',
-		activeFilesets: filesets,
-		defaultLanguageIso: bible.iso || 'eng',
-		defaultLanguageName: bible.language || 'English',
-		defaultLanguageCode: bible.language_id || 6414,
-		activeTextName: bible.vname || bible.name,
-		activeBookId: bookId.toUpperCase(),
-		userProfile,
-		userId: userId || '',
-		isAuthenticated: isAuthenticated || false,
-		isFromServer,
-		isIe,
-		routeLocation,
-		match: {
-			params: {
-				bibleId,
-				bookId,
-				chapter,
-				verse,
-				token,
-			},
-		},
-		fetchedUrls: [],
-		triggerRedirect,
-	};
+  if (typeof document !== 'undefined') {
+    document.cookie = `bible_is_ref_bible_id=${bibleId}`;
+    document.cookie = `bible_is_ref_book_id=${bookId}`;
+    document.cookie = `bible_is_ref_chapter=${chapter}`;
+    document.cookie = `bible_is_ref_verse=${verse}`;
+  }
+  return {
+    initialVolume,
+    initialPlaybackRate,
+    chapterText,
+    testaments,
+    audioType: audioType || '',
+    formattedText: initData.formattedText,
+    books: bookData || [],
+    activeChapter: parseInt(chapter, 10) >= 0 ? parseInt(chapter, 10) : 1,
+    activeBookName,
+    verseNumber: verse,
+    activeTextId: bible.abbr,
+    activeIsoCode: bible.iso,
+    activeLanguageName: bible.language,
+    textDirection: bible.alphabet ? bible.alphabet.direction : 'ltr',
+    activeFilesets: filesets,
+    defaultLanguageIso: bible.iso || 'eng',
+    defaultLanguageName: bible.language || 'English',
+    defaultLanguageCode: bible.language_id || 6414,
+    activeTextName: bible.vname || bible.name,
+    activeBookId: bookId.toUpperCase(),
+    userProfile,
+    userId: userId || '',
+    isAuthenticated: isAuthenticated || false,
+    isFromServer,
+    isIe,
+    routeLocation,
+    match: {
+      params: {
+        bibleId,
+        bookId,
+        chapter,
+        verse,
+        token,
+      },
+    },
+    fetchedUrls: [],
+    triggerRedirect,
+  };
 };
 
 AppContainer.propTypes = {
-	dispatch: PropTypes.func,
-	match: PropTypes.object,
-	userProfile: PropTypes.object,
-	chapterText: PropTypes.array,
-	fetchedUrls: PropTypes.array,
-	isFromServer: PropTypes.bool,
-	isIe: PropTypes.bool,
-	routeLocation: PropTypes.string,
-	activeBookName: PropTypes.string,
-	formattedText: PropTypes.string,
-	activeChapter: PropTypes.number,
-	initialVolume: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
-	initialPlaybackRate: PropTypes.oneOfType([
-		PropTypes.number,
-		PropTypes.string,
-	]),
-	triggerRedirect: PropTypes.shape({
-		url: PropTypes.string,
-		as: PropTypes.string,
-	}),
+  dispatch: PropTypes.func,
+  match: PropTypes.object,
+  userProfile: PropTypes.object,
+  chapterText: PropTypes.array,
+  fetchedUrls: PropTypes.array,
+  isFromServer: PropTypes.bool,
+  isIe: PropTypes.bool,
+  routeLocation: PropTypes.string,
+  activeBookName: PropTypes.string,
+  formattedText: PropTypes.string,
+  activeChapter: PropTypes.number,
+  initialVolume: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+  initialPlaybackRate: PropTypes.oneOfType([
+    PropTypes.number,
+    PropTypes.string,
+  ]),
+  triggerRedirect: PropTypes.shape({
+    url: PropTypes.string,
+    as: PropTypes.string,
+  }),
 };
 
 export default connect()(AppContainer);


### PR DESCRIPTION
# Description
When an user tries to changes the bible using the top menu the filesets are not being filtered and so, it is trying to retrieve incorrect filesets that don’t match with the selected book. We must to avoid pulling filesets that doesn't match with correct testament.

## Related Issue

https://fullstacklabs.atlassian.net/browse/FCBHDBP-576

## How to Test
- You should go the path: bible/JPNCJV/MAT/1 and it must load the correct page and the console doesn't render errors.
- You should go the path: biible/en1esv/mat/1 and it must load the correct page and the console doesn't render errors.
- You should go the path: biible/jpncjv/rut/2 and it must load the correct page and the console doesn't render errors.
- You should go the path: biible/engweb/mat/2 and it must load the correct page and the console doesn't render errors.
- You should go the path: bible/FRAPDF/MAT/1, it must load the correct page, the console doesn't render errors and it doesn't render request with 404 code.
- You should go a specific Algeria bible and it must load the correct page as you see in the following .gif.

![Peek 2023-06-02 01-28](https://github.com/faithcomesbyhearing/dbp-web/assets/73488660/91409a63-c1a0-4a56-834f-1c9b2f16cad9)

