### PR TITLE
Ticket-2320 Implemented caching on the server side

### DIFF
--- a/app/components/VersionListSection/tests/index.test.js
+++ b/app/components/VersionListSection/tests/index.test.js
@@ -121,6 +121,6 @@ describe('<VersionListSection />', () => {
 		const wrapper = Enzyme.mount(
 			<VersionListSection items={sectionItems} />,
 		);
-		expect(wrapper.find('div.accordion-body-style').length).toEqual(4);
+		expect(wrapper.find('div.accordion-body-style').length).toEqual(1);
 	});
 });

--- a/app/utils/cachedFetch.js
+++ b/app/utils/cachedFetch.js
@@ -1,26 +1,30 @@
 import lscache from 'lscache';
 import axios from 'axios';
+import { LRUCache } from 'lru-cache';
 
-// Set a default expiry for 5 minutes in development 24 hours in production
-const TTL_MINUTES =	 process.env.NODE_ENV === 'development'
-		? 1000 * 60 * 5
-		: 1000 * 60 * 60 * 24;
+// Define TTL for the server and client separately
+const SERVER_TTL_MINUTES = process.env.NODE_ENV === 'development' ? 1000 * 60 : 1000 * 60 * 60 * 24; // 24 hours in production, 1 minute in development
+const CLIENT_TTL_MINUTES = process.env.NODE_ENV === 'development' ? 1000 * 60 * 5 : 1000 * 60 * 60 * 24; // 24 hours in production, 5 minutes in development
+
+// Server-side cache using LRUCache
+const cache = new LRUCache({ max: 500, ttl: SERVER_TTL_MINUTES }); // Server-side TTL
 
 export default async function cachedFetch(url, options, expires) {
 	// On the first load we flush any expired values
 	lscache.flushExpired();
 	// Makes the expiry time unit milliseconds
 	lscache.setExpiryMilliseconds(1);
-	// We don't cache anything when server-side rendering. Because there isn't local storage
-	// That way if users refresh the page they always get fresh data.
+	// Server-side logic: use in-memory cache
 	if (typeof window === 'undefined') {
-		// If the call is to countries or languages then cache it anyway
-		// We only want those to update once every 24 hours
-		if (expires) {
-			// don't return because I want this to always return the cached item until it expires
-		} else {
-			return axios.get(url, options).then((response) => response.data);
+		const cachedResponse = cache.get(url);
+		if (cachedResponse) {
+			return cachedResponse; // Return from memory cache
 		}
+
+		// If not in cache, make API call and store it in memory cache
+		const apiResponse = await axios.get(url, options).then((response) => response.data);
+		cache.set(url, apiResponse, expires || SERVER_TTL_MINUTES);
+		return apiResponse;
 	}
 
 	let cachedResponse = lscache.get(url);
@@ -30,16 +34,23 @@ export default async function cachedFetch(url, options, expires) {
 		cachedResponse = await axios.get(url, options).then((response) =>
 			response.data,
 		);
-		lscache.set(url, cachedResponse, expires || TTL_MINUTES);
+		lscache.set(url, cachedResponse, expires || CLIENT_TTL_MINUTES);
 	}
 
 	return cachedResponse;
 }
 
 export function overrideCache(key, val, expires) {
-	lscache.set(key, val, expires || TTL_MINUTES);
+	if (typeof window === 'undefined') {
+		cache.set(key, val, expires || SERVER_TTL_MINUTES);
+	} else {
+		lscache.set(key, val, expires || CLIENT_TTL_MINUTES);
+	}
 }
 
 export function logCache(itemUrl) {
+	if (typeof window === 'undefined') {
+		return cache.get(itemUrl);
+	}
 	return lscache.get(itemUrl);
 }

--- a/app/utils/getInitialChapterData.js
+++ b/app/utils/getInitialChapterData.js
@@ -1,5 +1,4 @@
-import axios from 'axios';
-import request from './request';
+import cachedFetch from './cachedFetch';
 
 export default async ({
   plainFilesetIds,
@@ -14,15 +13,15 @@ export default async ({
     const url = `${process.env.BASE_API_ROUTE}/bibles/filesets/${id}?key=${
       process.env.DBP_API_KEY
     }&v=4&book_id=${bookId}&chapter_id=${chapter}&type=text_format`;
-    const res = await request(url).catch((e) => {
+    const res = await cachedFetch(url).catch((e) => {
       if (process.env.NODE_ENV === 'development') {
-        console.log('Error in request for formatted fileset: ', e.message); // eslint-disable-line no-console
+        console.log('Error in request for formatted fileset: ', e); // eslint-disable-line no-console
       }
     });
     const path = res && res.data && res.data[0] && res.data[0].path;
     let text = '';
     if (path) {
-      text = await axios.get(path)
+      text = await cachedFetch(path)
         .then((textRes) => textRes.data)
         .catch((e) => {
           if (process.env.NODE_ENV === 'development') {
@@ -42,14 +41,14 @@ export default async ({
     }/bibles/filesets/${id}/${bookId}/${chapter}?key=${
       process.env.DBP_API_KEY
     }&v=4`;
-    const res = await request(url)
+    const res = await cachedFetch(url)
       .then((json) => {
         plainTextJson = JSON.stringify(json.data);
         return json;
       })
       .catch((e) => {
         if (process.env.NODE_ENV === 'development') {
-          console.error('Error in request for plain fileset: ', e.message, 'url', url); // eslint-disable-line no-console
+          console.error('Error in request for plain fileset: ', 'url', url, e); // eslint-disable-line no-console
         }
         return { data: [] };
       });


### PR DESCRIPTION
# Description
Implement a memory-based caching solution for server-side rendering. According to this solution, when the code runs on the server, `lru-cache` is used to store API responses. This cache will persist during the server process lifecycle but will be cleared when the server restarts. When the code runs on the client, `lscache` will handle caching using localStorage. This approach ensures that when getInitialProps runs on both server and client, the API request is not repeated.

# Task
[User Story 2320](https://dev.azure.com/keyholesoftware/FCBH%20-%20Bible%20Brain/_workitems/edit/2320): Bible.is web: Implemented caching on the server side

# How to test
You should run the test and it must return successful.

```shell
npm run test
``` 