### PR TITLE
Ticket-2021 and ticket-2478. dbp-web: enable display of Covenant Films

### DIFF
--- a/app/components/BooksTable/index.js
+++ b/app/components/BooksTable/index.js
@@ -12,6 +12,13 @@ import PropTypes from 'prop-types';
 import LoadingSpinner from '../LoadingSpinner';
 import BooksTestament from '../BooksTestament';
 import {
+	BOOK_COVENANT_TESTAMENT,
+	BOOK_NEW_TESTAMENT,
+	BOOK_OLD_TESTAMENT,
+	BOOK_AP_TESTAMENT,
+	BOOK_DEU_TESTAMENT,
+} from '../../constants/books';
+import {
 	selectAuthenticationStatus,
 	selectUserId,
 	selectAudioType,
@@ -96,17 +103,30 @@ export class BooksTable extends React.PureComponent {
 		this[name] = el;
 	};
 
-	render() {
-		const {
-			books,
-			audioType,
-			activeTextId,
-			activeChapter,
-			activeBookName,
-			loadingBooks,
-			textDirection,
-		} = this.props;
+	renderBooksTestament = (books, prefix, title) => {
+		const { audioType, activeTextId, activeChapter, activeBookName } =
+			this.props;
 		const { selectedBookName } = this.state;
+
+		return (
+			<BooksTestament
+				books={books}
+				testamentPrefix={prefix}
+				testamentTitle={title}
+				selectedBookName={selectedBookName}
+				handleRef={this.handleRef}
+				handleBookClick={this.handleBookClick}
+				handleChapterClick={this.handleChapterClick}
+				audioType={audioType}
+				activeBookName={activeBookName}
+				activeTextId={activeTextId}
+				activeChapter={activeChapter}
+			/>
+		);
+	};
+
+	render() {
+		const { books, loadingBooks, textDirection } = this.props;
 
 		if (loadingBooks) {
 			return <LoadingSpinner />;
@@ -123,51 +143,30 @@ export class BooksTable extends React.PureComponent {
 					ref={(el) => this.handleRef(el, 'container')}
 					className="book-container"
 				>
-					{!!books.get('OT') && (
-						<BooksTestament
-							books={books.get('OT')}
-							testamentPrefix={'ot'}
-							testamentTitle={'Old Testament'}
-							selectedBookName={selectedBookName}
-							handleRef={this.handleRef}
-							handleBookClick={this.handleBookClick}
-							handleChapterClick={this.handleChapterClick}
-							audioType={audioType}
-							activeBookName={activeBookName}
-							activeTextId={activeTextId}
-							activeChapter={activeChapter}
-						/>
-					)}
-					{!!books.get('NT') && (
-						<BooksTestament
-							books={books.get('NT')}
-							testamentPrefix={'nt'}
-							testamentTitle={'New Testament'}
-							selectedBookName={selectedBookName}
-							handleRef={this.handleRef}
-							handleBookClick={this.handleBookClick}
-							handleChapterClick={this.handleChapterClick}
-							audioType={audioType}
-							activeBookName={activeBookName}
-							activeTextId={activeTextId}
-							activeChapter={activeChapter}
-						/>
-					)}
-					{!!(books.get('AP') || !!books.get('DC')) && (
-						<BooksTestament
-							books={books.get('AP') || books.get('DC')}
-							testamentPrefix={'dc'}
-							testamentTitle={'Deuterocanon'}
-							selectedBookName={selectedBookName}
-							handleRef={this.handleRef}
-							handleBookClick={this.handleBookClick}
-							handleChapterClick={this.handleChapterClick}
-							audioType={audioType}
-							activeBookName={activeBookName}
-							activeTextId={activeTextId}
-							activeChapter={activeChapter}
-						/>
-					)}
+					{books.get(BOOK_OLD_TESTAMENT) &&
+						this.renderBooksTestament(
+							books.get(BOOK_OLD_TESTAMENT),
+							'ot',
+							'Old Testament',
+						)}
+					{books.get(BOOK_NEW_TESTAMENT) &&
+						this.renderBooksTestament(
+							books.get(BOOK_NEW_TESTAMENT),
+							'nt',
+							'New Testament',
+						)}
+					{(books.get(BOOK_AP_TESTAMENT) || books.get(BOOK_DEU_TESTAMENT)) &&
+						this.renderBooksTestament(
+							books.get(BOOK_AP_TESTAMENT) || books.get(BOOK_DEU_TESTAMENT),
+							'dc',
+							'Deuterocanon',
+						)}
+					{books.get(BOOK_COVENANT_TESTAMENT) &&
+						this.renderBooksTestament(
+							books.get(BOOK_COVENANT_TESTAMENT),
+							'cv',
+							'Covenant Films',
+						)}
 				</div>
 			</div>
 		);
@@ -209,9 +208,6 @@ function mapDispatchToProps(dispatch) {
 	};
 }
 
-const withConnect = connect(
-	mapStateToProps,
-	mapDispatchToProps,
-);
+const withConnect = connect(mapStateToProps, mapDispatchToProps);
 
 export default compose(withConnect)(BooksTable);

--- a/app/constants/books.js
+++ b/app/constants/books.js
@@ -1,0 +1,5 @@
+export const BOOK_NEW_TESTAMENT = 'NT';
+export const BOOK_OLD_TESTAMENT = 'OT';
+export const BOOK_AP_TESTAMENT = 'AP';
+export const BOOK_DEU_TESTAMENT = 'DC';
+export const BOOK_COVENANT_TESTAMENT = 'CV';

--- a/app/utils/getValidFilesetsByBook.js
+++ b/app/utils/getValidFilesetsByBook.js
@@ -1,4 +1,5 @@
-import { FILESET_SIZE_COMPLETE } from '../constants/bibleFileset';
+import { FILESET_SIZE_COMPLETE, FILESET_SIZE_STORIES } from '../constants/bibleFileset';
+import { BOOK_COVENANT_TESTAMENT } from '../constants/books';
 
 /**
  * Filter the list of plain Fileset Ids to include only those that belong to the same testament as the given book.
@@ -53,9 +54,10 @@ const getValidFilesetsByBook = (
 
     const isCompleteTestament = filesetMetadata.testament === FILESET_SIZE_COMPLETE;
     const isMatchingTestament = filesetMetadata.testament.includes(book.testament);
+    const isCovenantTestament = FILESET_SIZE_STORIES === filesetMetadata.testament && book.testament === BOOK_COVENANT_TESTAMENT;
     const isBookAllowed = filesetMetadata.booksAllowed[book.book_id];
 
-    return (isCompleteTestament || isMatchingTestament) && isBookAllowed;
+    return (isCompleteTestament || isMatchingTestament || isCovenantTestament) && isBookAllowed;
   });
 };
 

--- a/pages/app.js
+++ b/pages/app.js
@@ -479,8 +479,7 @@ AppContainer.getInitialProps = async (context) => {
   // Redirect to the new url if conditions are met
   if (bookMetaData && bookMetaData.length) {
     const foundChapter =
-      foundBook &&
-      foundBook.chapters.find((c) => chapter && c === parseInt(chapter, 10));
+      foundBook?.chapters.find((c) => chapter && c === parseInt(chapter, 10));
     // Default book/chapter to matthew 1 to keep it from breaking if there is an error encountered in getFirstChapterReference
     let bookChapterRoute = 'MAT/1';
     // Handles getting the book/chapter that follows Jon Stearley's methodology


### PR DESCRIPTION
# Description
Updated the logic to support the covenant films.  I have incorporated the logic to render the covenant films books in the header bar and additionally, I have changed the logic to filter the filesets to support the video covenant films which will have the set_size_code= "S" and the book.testament = "CV"

> [!IMPORTANT]
This ticket is related to the following dbp-etl and dbp PRs:

- https://github.com/faithcomesbyhearing/dbp-etl/pull/178
- https://github.com/faithcomesbyhearing/dbp/pull/1004

# Task
[User Story 2478](https://dev.azure.com/keyholesoftware/FCBH%20-%20Bible%20Brain/_workitems/edit/2478): dbp-web: enable display of Covenant Films
[User Story 2021](https://dev.azure.com/keyholesoftware/FCBH%20-%20Bible%20Brain/_workitems/edit/2021): uploader needs to recognize Covenant film content

# Screenshot
You can see in the following recording the example of a bible [ACECOV](https://newdata.bible.is/bible/ACECOV)
[Peek 2025-01-05 20-14.webm](https://github.com/user-attachments/assets/3bbdfbdb-5059-454d-8640-94b99945e731)

