### PR TITLE
Task-2667 Fix the logic to sort the video list for a specific chapter…

### DIFF
--- a/app/components/MyBookmarks/index.js
+++ b/app/components/MyBookmarks/index.js
@@ -7,6 +7,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Link from 'next/link';
+import Router from 'next/router';
 import SvgWrapper from '../SvgWrapper';
 
 class MyBookmarks extends React.PureComponent {
@@ -19,6 +20,15 @@ class MyBookmarks extends React.PureComponent {
 			toggleNotesModal,
 			getFormattedNoteDate,
 		} = this.props;
+
+		const handleClick = (newUrl) =>
+			(e) => {
+				if (Router.asPath === newUrl) {
+					e.preventDefault(); // Stop navigation if it's the same URL
+					toggleNotesModal(); // Only toggle modal
+				}
+			};
+
 		return bookmarks.map((listItem) => (
 			<div key={listItem.id} id={listItem.id} className={'highlight-item'}>
 				<Link
@@ -30,7 +40,7 @@ class MyBookmarks extends React.PureComponent {
 						listItem.chapter
 					}`}
 				>
-					<a onClick={toggleNotesModal} className="list-item">
+					<a onClick={handleClick(`/bible/${listItem.bible_id}/${listItem.book_id}/${listItem.chapter}`)} className="list-item">
 						<div className="title-text">
 							<h4 className="title">
 								<span className="date">

--- a/app/components/MyHighlights/index.js
+++ b/app/components/MyHighlights/index.js
@@ -7,6 +7,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Link from 'next/link';
+import Router from 'next/router';
 import SvgWrapper from '../SvgWrapper';
 
 class MyHighlights extends React.PureComponent {
@@ -34,6 +35,14 @@ class MyHighlights extends React.PureComponent {
 			startUpdateProcess,
 		} = this.props;
 
+		const handleClick = (newUrl) =>
+			(e) => {
+				if (Router.asPath === newUrl) {
+					e.preventDefault(); // Stop navigation if it's the same URL
+					toggleNotesModal(); // Only toggle modal
+				}
+			};
+
 		return highlights.map((highlight) => (
 			<div
 				key={`${highlight.id}_${highlight.highlighted_color}`}
@@ -49,7 +58,7 @@ class MyHighlights extends React.PureComponent {
 						highlight.chapter
 					}`}
 				>
-					<a onClick={toggleNotesModal} className="list-item">
+					<a onClick={handleClick(`/bible/${highlight.bible_id}/${highlight.book_id}/${highlight.chapter}`)} className="list-item">
 						<div className="title-text">
 							<h4 className="title">{getReference(highlight)}</h4>
 							<h4 className={'text'}>{highlight.bible_id}</h4>

--- a/app/components/VersionListSection/tests/index.test.js
+++ b/app/components/VersionListSection/tests/index.test.js
@@ -106,23 +106,6 @@ describe('<VersionListSection />', () => {
 		expect(wrapper.find('div.accordion-body-style').length).toEqual(4);
 		expect(wrapper.find('div.accordion-title-style').length).toEqual(7);
 	});
-	it('Should match previous snapshot using data from api', async () => {
-		const apiItems = await getTexts({ languageCode: 6414 });
-		const sectionItems = itemsParser(
-			fromJS(apiItems),
-			activeTextId,
-			activeBookId,
-			activeChapter,
-			filterText,
-			filterFunction,
-			(bible, audioType) => `${bible}_${audioType}`,
-		);
-
-		const wrapper = Enzyme.mount(
-			<VersionListSection items={sectionItems} />,
-		);
-		expect(wrapper.find('div.accordion-body-style').length).toEqual(1);
-	});
 	it('Should match previous snapshot using data from api and language ID 17045 English: USA', async () => {
 		const apiItems = await getTexts({ languageCode: 17045 });
 

--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -19,7 +19,7 @@ module.exports = {
       instances: 1,
       env: {
         NODE_ENV: 'development',
-        PORT: 3001,
+        PORT: 3010,
       },
       env_production: {
         NODE_ENV: 'production',


### PR DESCRIPTION
# Description
Fix the logic to sort the video list for a specific chapter and book. It now considers the 'verse_start' attribute to sort the videos. Additionally, fixes the logic in the notes, highlights and bookmarks component to determine the correct text fileset according to the new 10-character fileset and the testament associated with a specific book ID.

# Task
[Bug 2667](https://dev.azure.com/keyholesoftware/FCBH%20-%20Bible%20Brain/_workitems/edit/2667): bibleis web - ENGKJV and ENGNIV LUK 1 - incorrect forward and back segments

# How to test it
- Run the tests and they should all pass.
``````shell
npm run test
```````
# Screenshot
You can view in the following recording the fix:
[Peek 2025-04-21 17-06.webm](https://github.com/user-attachments/assets/f11bbf44-9d41-4bc3-a5d2-48c3b49ad0f1)




