### PR TITLE
Task-2696 dbp-web: prefer text_json over text_format

### DIFF
--- a/app/components/FormattedJson/index.js
+++ b/app/components/FormattedJson/index.js
@@ -1,0 +1,709 @@
+/**
+ *
+ * FormattedJson Component
+ *
+ */
+import React, { useCallback, useMemo, useEffect } from 'react';
+import PropTypes from 'prop-types';
+import { useSelector } from 'react-redux';
+import { getItemClasses } from './styles';
+import {
+	calculateVerseProps,
+	findSubtypeRecursively,
+	extractTextRecursive,
+	extractFootnotesWithIndexKey,
+} from '../../containers/Text/formattedJsonUtils';
+
+/**
+ * RenderContentItem
+ * Recursively renders content items, handling strings and objects differently.
+ * Handles verse labels, chapter labels, footnotes, and other markers.
+ */
+const RenderContentItem = React.memo(
+	({
+		item,
+		bookCode, // Receive bookCode
+		currentVerseNumberInScope, // Scope passed from PARENT or preceding sibling
+		currentChapterNumberInScope,
+		// Other state/props passed down
+		currentPlayingVerse,
+		currentSelectedVerse, // Needed for verseId fallback in original code? Review this.
+		annotations,
+		// Event handlers passed down
+		onVerseClick,
+		onVerseMouseDown,
+		onVerseMouseUp,
+		onNoteClick,
+		onBookmarkClick,
+		onFootnoteClick,
+		fontSize,
+		blockIndex,
+		itemIndex, // Unique identifier for this item instance
+		activeVerseInfo,
+	}) => {
+		if (!item) return null;
+
+		// --- Handle Strings ---
+		if (typeof item === 'string') {
+			// Construct verseId using the *correct* scope passed to this instance
+			// Using the format from your index_js.txt (note the fallback to currentSelectedVerse, ensure this logic is intended)
+			const verseId =
+				bookCode && currentChapterNumberInScope && currentVerseNumberInScope
+					? `${bookCode}${currentChapterNumberInScope}_${currentVerseNumberInScope}`
+					: null; // Removed fallback to currentSelectedVerse here for clarity, add back if specifically needed for strings
+
+			const verseProps = calculateVerseProps(
+				currentVerseNumberInScope,
+				currentPlayingVerse,
+				currentSelectedVerse,
+				annotations,
+			);
+			// Only clickable/selectable if within a valid verse scope
+			const isClickable =
+				verseProps.isSelectable && !!currentVerseNumberInScope;
+			const highlightColor = verseProps.highlightData?.highlighted_color;
+			const classes = getItemClasses(null, {
+				isSelectable: isClickable,
+				isPlaying: verseProps.isPlaying,
+				highlightColor: !!highlightColor,
+				isActive: activeVerseInfo?.verse === currentVerseNumberInScope,
+			});
+			const inlineStyle = highlightColor
+				? { backgroundColor: highlightColor }
+				: {};
+			const verseInfo = isClickable
+				? {
+						chapter: currentChapterNumberInScope,
+						verse: currentVerseNumberInScope,
+				  }
+				: null;
+
+			return (
+				<span
+					className={classes}
+					style={inlineStyle}
+					data-id={verseId} // Add data-id
+					data-verse-number={currentVerseNumberInScope} // Add verse number
+					onMouseDown={
+						isClickable ? (e) => onVerseMouseDown(e, verseInfo) : undefined
+					}
+					onMouseUp={
+						isClickable ? (e) => onVerseMouseUp(e, verseInfo) : undefined
+					}
+					onClick={isClickable ? (e) => onVerseClick(e, verseInfo) : undefined}
+				>
+					{item}
+				</span>
+			);
+		}
+
+		let verseNumber = currentVerseNumberInScope; // Verse scope for THIS item
+		let chapterNumber = currentChapterNumberInScope; // Chapter scope for THIS item
+		let ElementType = 'span';
+		let isVerseLabel = false;
+		let isChapterLabel = false;
+		let isFootnote = false;
+		let isXref = false;
+
+		// Update scope based on THIS item's type/subtype
+		if (item?.subtype === 'verses_label' && item?.atts?.number) {
+			verseNumber = parseInt(item.atts.number, 10);
+			isVerseLabel = true;
+			ElementType = 'span';
+		} else if (item?.subtype === 'chapter_label' && item?.atts?.number) {
+			chapterNumber = parseInt(item.atts.number, 10);
+			isChapterLabel = true;
+			ElementType = 'h1'; // Or other prominent tag
+		} else if (item?.subtype === 'footnote') {
+			isFootnote = true;
+			ElementType = 'sup';
+		} else if (item?.subtype === 'xref') {
+			isXref = true;
+			ElementType = 'sup';
+		} else if (
+			['usfm:p', 'usfm:m', 'usfm:pi', 'usfm:q', 'usfm:q1', 'usfm:q2'].includes(
+				item.subtype,
+			)
+		) {
+			ElementType = 'p';
+		} else if (
+			[
+				'usfm:mt1',
+				'usfm:mt',
+				'usfm:s',
+				'usfm:s1',
+				'usfm:ms',
+				'title',
+				'heading',
+			].includes(item.subtype)
+		) {
+			ElementType = 'div';
+			// Adjust H levels later or via CSS
+		} else if (item.subtype === 'usfm:b') {
+			return <div className="verse-blank-line" />;
+		}
+
+		const verseId =
+			bookCode && chapterNumber && (verseNumber ?? currentSelectedVerse)
+				? `${bookCode}${chapterNumber}_${verseNumber ?? currentSelectedVerse}`
+				: null;
+
+		const verseProps = calculateVerseProps(
+			verseNumber,
+			currentPlayingVerse,
+			currentSelectedVerse,
+			annotations,
+		);
+		const highlightColor = verseProps.highlightData?.highlighted_color;
+		// Pass verseProps for class generation
+		const classes = getItemClasses(item, {
+			...verseProps,
+			highlightColor: !!highlightColor,
+		});
+		const inlineStyle = highlightColor
+			? { backgroundColor: highlightColor }
+			: {};
+		// Ensure key is unique, incorporating itemIndex which is now more detailed
+		const key = `item-${blockIndex}-${itemIndex}-${item.subtype || item.type}-${
+			verseId || chapterNumber
+		}`;
+
+		if (isVerseLabel) {
+			const verseInfo = { chapter: chapterNumber, verse: verseNumber };
+			// Use verseId constructed above for this specific label
+			return (
+				<ElementType // span
+					key={key}
+					className={classes} // Includes verse-number-label
+					style={inlineStyle}
+					data-verse-number={verseNumber}
+					data-id={verseId} // Add data-id HERE
+					onMouseDown={(e) => onVerseMouseDown(e, verseInfo)}
+					onMouseUp={(e) => onVerseMouseUp(e, verseInfo)}
+					onClick={(e) => onVerseClick(e, verseInfo)}
+				>
+					{/* Icons using SVG */}
+					{verseProps.hasNote && (
+						<svg
+							className="icon icon-note"
+							aria-label="Note"
+							onClick={(e) => {
+								e.stopPropagation();
+								onNoteClick(e, verseInfo);
+							}}
+							width="1em"
+							height="1em"
+						>
+							<use
+								xmlnsXlink="http://www.w3.org/1999/xlink"
+								xlinkHref="/svglist.svg#note_in_verse"
+							>
+								{/* Note icon */}
+							</use>
+						</svg>
+					)}
+					{verseProps.hasBookmark && (
+						<svg
+							className="icon bookmark-in-verse"
+							aria-label="Bookmark"
+							onClick={(e) => {
+								e.stopPropagation();
+								onBookmarkClick(e, verseInfo);
+							}}
+							width="1em"
+							height="1em"
+						>
+							<use
+								xmlnsXlink="http://www.w3.org/1999/xlink"
+								xlinkHref="/svglist.svg#bookmark_in_verse"
+							>
+       </use>
+						</svg>
+					)}
+					{item?.atts?.number} {/* Render the number */}
+					&nbsp;
+				</ElementType>
+			);
+		}
+
+		if (isChapterLabel) {
+			return (
+				<ElementType
+					key={key}
+					className={classes}
+					data-chapter-number={chapterNumber}
+					data-id={verseId}
+				>
+					{item?.atts?.number}
+					{/* Recursively render content if chapter label has nested content? Optional. */}
+				</ElementType>
+			);
+		}
+
+		if (isFootnote || isXref) {
+			let marker = '?'; // Default marker
+			let footnoteText = '';
+
+			try {
+				// Extract content based on the observed graft structure
+				const footnoteBlockContent = item.sequence?.blocks?.[0]?.content;
+
+				if (Array.isArray(footnoteBlockContent)) {
+					// Find Caller (assuming it's always the '+' inside note_caller graft)
+					const callerGraft = footnoteBlockContent.find(
+						(c) => c?.type === 'graft' && c?.subtype === 'note_caller',
+					);
+					// Extract deeply nested caller symbol
+					marker = callerGraft?.sequence?.blocks?.[0]?.content?.[0] || marker;
+
+					// Find Text Wrapper (usfm:ft)
+					const textWrapper = footnoteBlockContent.find(
+						(c) => c?.type === 'wrapper' && c?.subtype === 'usfm:ft',
+					);
+					if (textWrapper?.content) {
+						footnoteText = extractTextRecursive(textWrapper.content);
+					}
+				}
+			} catch (e) {
+				console.error('Error parsing footnote graft structure:', e, item); // eslint-disable-line no-console
+			}
+
+			// Information to pass to the click handler
+			const footnoteIdForHandler = `fn-${footnoteText.replace(/\s+/g, '_')}`;
+			// Since text is available, we pass it directly. No need for ID lookup.
+			const clickInfo = {
+				footnoteId: footnoteIdForHandler,
+				caller: marker,
+				text: footnoteText,
+			};
+
+			return (
+				<sup
+					key={key} // Ensure unique key
+					className={classes} // Apply classes ('verse-content-item', 'verse-footnote-marker')
+					title={footnoteText || 'Footnote'} // Show full text on hover
+					onClick={(e) => {
+						e.stopPropagation(); // Prevent parent clicks if necessary
+						onFootnoteClick(e, clickInfo); // Pass extracted info
+					}}
+					style={{ cursor: 'pointer' }} // Indicate it's clickable
+				>
+					{marker} {/* Display the extracted marker ('+') */}
+				</sup>
+			);
+		}
+
+		const renderChildren = () => {
+			const contentArray = item.content; // Content of THIS item
+			// Initialize tracker with the verse scope determined for THIS item
+			let lastSeenVerseInContent = verseNumber;
+			const childrenElements = [];
+
+			if (!Array.isArray(contentArray)) {
+				return null;
+			}
+			// Iterate over children of this item
+			contentArray.forEach((childItemData, index) => {
+				// const childItemData = contentArray[i];
+				// Verse scope for this child defaults to the last seen number
+				let verseScopeForChild = lastSeenVerseInContent;
+
+				// Check if this child item *is* a verse label to update scope for *next* siblings
+				if (
+					typeof childItemData === 'object' &&
+					childItemData?.subtype === 'verses_label' &&
+					childItemData?.atts?.number
+				) {
+					const currentChildVerseNumber = parseInt(
+						childItemData.atts.number,
+						10,
+					);
+					// The label uses its own number for its scope
+					verseScopeForChild = currentChildVerseNumber;
+					// Update tracker for subsequent siblings
+					lastSeenVerseInContent = currentChildVerseNumber;
+				}
+				// If it's a string or other object, it uses the tracked verseScopeForChild
+				const childKey = `child-${itemIndex}-${index}`;
+				childrenElements.push(
+					<RenderContentItem
+						// Use a more detailed key combining parent itemIndex and child index
+						key={childKey}
+						item={childItemData}
+						bookCode={bookCode}
+						// Pass the correctly tracked verse scope for THIS child
+						currentVerseNumberInScope={verseScopeForChild}
+						// Chapter scope is passed down
+						currentChapterNumberInScope={chapterNumber}
+						// Pass down all other necessary props
+						currentPlayingVerse={currentPlayingVerse}
+						currentSelectedVerse={currentSelectedVerse} // Pass down for potential use in verseId fallback or props calc
+						annotations={annotations}
+						onVerseClick={onVerseClick}
+						onVerseMouseDown={onVerseMouseDown}
+						onVerseMouseUp={onVerseMouseUp}
+						onNoteClick={onNoteClick}
+						onBookmarkClick={onBookmarkClick}
+						onFootnoteClick={onFootnoteClick}
+						fontSize={fontSize}
+						blockIndex={blockIndex} // Keep original blockIndex from parent
+						itemIndex={`${itemIndex}-${index}`} // Create nested itemIndex string
+					/>,
+				);
+			});
+			return childrenElements;
+		};
+
+		return (
+			<ElementType
+				key={key}
+				className={classes}
+				style={inlineStyle}
+				data-verse-number={verseNumber}
+			>
+				{renderChildren()}
+			</ElementType>
+		);
+	},
+);
+
+RenderContentItem.propTypes = {
+	item: PropTypes.oneOfType([PropTypes.string, PropTypes.object]).isRequired,
+	bookCode: PropTypes.string,
+	currentVerseNumberInScope: PropTypes.oneOfType([
+		PropTypes.number,
+		PropTypes.string,
+	]),
+	currentChapterNumberInScope: PropTypes.oneOfType([
+		PropTypes.number,
+		PropTypes.string,
+	]),
+	currentPlayingVerse: PropTypes.any,
+	currentSelectedVerse: PropTypes.any,
+	annotations: PropTypes.object,
+	onVerseClick: PropTypes.func,
+	onVerseMouseDown: PropTypes.func,
+	onVerseMouseUp: PropTypes.func,
+	onNoteClick: PropTypes.func,
+	onBookmarkClick: PropTypes.func,
+	onFootnoteClick: PropTypes.func,
+	fontSize: PropTypes.number,
+	blockIndex: PropTypes.number,
+	itemIndex: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+	activeVerseInfo: PropTypes.object,
+};
+
+function FormattedJson({
+	userNotes,
+	bookmarks,
+	highlights,
+	userSettings,
+	activeVerseInfo,
+	activeChapter, // Prop from parent
+	activeBookId, // Prop from parent
+	formattedSource, // Assuming this prop provides the JSON data now
+	// Event Handlers passed from parent container:
+	openFootnote,
+	setFootnotes,
+	handleMouseUp,
+	getFirstVerse,
+	handleNoteClick,
+}) {
+	const chapterJson = formattedSource;
+
+	// Extract footnotes into a map with generated keys when chapterJson changes
+	const footnotesMapWithIndex = useMemo(() => {
+		if (chapterJson) {
+			return extractFootnotesWithIndexKey(chapterJson);
+		}
+		return {};
+	}, [chapterJson]);
+
+	// Call setFootnotes when the map changes
+	useEffect(() => {
+		// Check if setFootnotes is provided and the map is not empty
+		if (setFootnotes && Object.keys(footnotesMapWithIndex).length > 0) {
+			// Initialize footnotes object to store extracted text
+			const footnotes = {};
+			Object.keys(footnotesMapWithIndex).forEach((key) => {
+				const { text } = footnotesMapWithIndex[key] || {};
+				footnotes[key] = text;
+			});
+			setFootnotes(footnotes);
+		}
+	}, [footnotesMapWithIndex, setFootnotes]);
+
+	useEffect(() => {
+		if (!activeVerseInfo?.verse) {
+			document.querySelectorAll('.active-verse').forEach((node) => {
+				node.classList.remove('active-verse');
+			});
+		}
+	}, [activeVerseInfo]);
+
+	// Select player/selection state from Redux store (adjust paths as needed)
+	const currentPlayingVerse = useSelector(
+		(state) => state.player?.currentVerse,
+	);
+	const currentSelectedVerse = useSelector(
+		(state) => state.selection?.selectedVerse,
+	);
+
+	// Consolidate annotations
+	const annotations = useMemo(
+		() => ({
+			notes: userNotes || [],
+			bookmarks: bookmarks || [],
+			highlights: highlights || [],
+		}),
+		[userNotes, bookmarks, highlights],
+	);
+
+	// Extract metadata (use props like activeBookId/activeChapter as fallback if needed)
+	const bookCode = useMemo(
+		() => chapterJson?.metadata?.document?.bookCode || activeBookId,
+		[chapterJson, activeBookId],
+	);
+
+	const chapterNumberFromJson = useMemo(
+		() =>
+			parseInt(
+				chapterJson?.metadata?.document?.properties?.chapters || '0',
+				10,
+			) || activeChapter,
+		[chapterJson, activeChapter],
+	);
+
+	// --- Define Wrapper Handlers ---
+	const handleVerseMouseDownWrapper = useCallback(
+		(event, verseInfo) => {
+			if (getFirstVerse && verseInfo) {
+				getFirstVerse(event, verseInfo.verse);
+			}
+		},
+		[getFirstVerse],
+	);
+
+	const handleVerseMouseUpWrapper = useCallback(
+		(event) => {
+			if (handleMouseUp) {
+				handleMouseUp(event);
+			}
+		},
+		[handleMouseUp],
+	);
+
+	const handleNoteIconClickWrapper = useCallback(
+		(event, verseInfo) => {
+			if (handleNoteClick && verseInfo) {
+				event.stopPropagation();
+				annotations?.notes?.forEach((annotation, index) => {
+					if (annotation.verse_start === verseInfo.verse) {
+						// Assuming the note click handler uses the index to identify the note
+						handleNoteClick(index, false);
+					}
+				});
+			}
+		},
+		[handleNoteClick, annotations],
+	);
+
+	const handleBookmarkIconClickWrapper = useCallback(
+		(event, verseInfo) => {
+			if (handleNoteClick && verseInfo) {
+				// Assuming same handler
+				event.stopPropagation();
+				handleNoteClick(verseInfo, true);
+			}
+		},
+		[handleNoteClick],
+	);
+
+	const handleFootnoteClickWrapper = useCallback(
+		(event, footnoteInfo) => {
+			if (openFootnote && footnoteInfo.text) {
+				// Pass the extracted text and caller symbol directly
+				event.stopPropagation();
+				if (typeof window !== 'undefined') {
+					const rightEdge = window.innerWidth - 300;
+					const x = rightEdge < event.clientX ? rightEdge : event.clientX;
+					openFootnote({
+						id: footnoteInfo.footnoteId,
+						coords: { x, y: event.clientY },
+					});
+				}
+			} else {
+				/* eslint-disable no-console */
+				console.warn(
+					'Cannot open footnote, missing text or handler:',
+					footnoteInfo,
+				);
+				/* eslint-disable no-console */
+			}
+		},
+		[openFootnote],
+	);
+
+	const justifiedText =
+		userSettings?.toggleOptions?.justifiedText?.active || false;
+	const fontSize = userSettings?.toggleOptions?.readersFontScale?.active || 16;
+
+	const renderedBlocks = useMemo(() => {
+		// Ensure we have the JSON data structure expected
+		if (!chapterJson?.sequence?.blocks) {
+			// Handle case where data might still be in old HTML format or loading
+			if (typeof chapterJson?.main === 'string') {
+				console.warn(
+					// eslint-disable no-console
+					'FormattedJson received HTML string, expected JSON object.',
+				);
+				// Optionally render the old HTML as a fallback during transition?
+				// return <div dangerouslySetInnerHTML={{ __html: chapterJson.main }} />;
+				return <div>Error: Invalid data format. Expected JSON.</div>;
+			}
+			return <div>Loading...</div>;
+		}
+
+		let currentChapterCtx = chapterNumberFromJson; // Use chapter number derived from JSON/props
+
+		return chapterJson.sequence.blocks.map((block, blockIndex) => {
+			if (
+				['remark', 'introduction'].includes(block?.sequence?.type) ||
+				block?.subtype === 'orphanTokens'
+			) {
+				return null;
+			}
+
+			let BlockElementType = 'div';
+			const blockSubtype =
+				block.subtype || (block.type === 'graft' ? block.sequence?.type : null);
+			if (
+				[
+					'usfm:p',
+					'usfm:m',
+					'usfm:pi',
+					'usfm:q',
+					'usfm:q1',
+					'usfm:q2',
+				].includes(blockSubtype)
+			) BlockElementType = 'div';
+			else if (
+				[
+					'usfm:mt1',
+					'usfm:mt',
+					'usfm:s',
+					'usfm:s1',
+					'usfm:ms',
+					'title',
+					'heading',
+				].includes(blockSubtype)
+			) BlockElementType = 'div';
+
+			const blockClasses = getItemClasses(block);
+			const key = `block-${blockIndex}-${block.type}-${
+				blockSubtype || block?.sequence?.type
+			}`;
+
+			const chapterLabel = findSubtypeRecursively(
+				block.content,
+				'chapter_label',
+			);
+			if (chapterLabel?.atts?.number) {
+				currentChapterCtx = parseInt(chapterLabel.atts.number, 10);
+			}
+
+			const contentSource =
+				block.type === 'graft' ? block.sequence?.blocks : block.content;
+
+			const handleVerseOnClick = (event, verseInfo) => {
+				// Check if verseInfo has valid chapter and verse
+				if (verseInfo?.verse && verseInfo?.chapter) {
+					document.querySelectorAll('.active-verse').forEach((node) => {
+						if (node !== event.target) {
+							node.classList.remove('active-verse');
+						}
+					});
+					const verseId = `${bookCode}${verseInfo.chapter}_${verseInfo.verse}`;
+					// Then add the class to the target element if its data-id matches the verseId
+					if (event.target.dataset.id === verseId) {
+						event.target.classList.add('active-verse');
+					}
+				}
+			};
+			return (
+				<BlockElementType key={key} className={blockClasses}>
+					{Array.isArray(contentSource) &&
+						contentSource.map((item, itemIndex) => {
+							const keyItem = `item-${blockIndex}-${itemIndex}`;
+							return (
+								<RenderContentItem
+									key={keyItem}
+									item={item}
+									bookCode={bookCode} // Pass bookCode
+									currentVerseNumberInScope={null} // Verse scope starts within item's content
+									currentChapterNumberInScope={currentChapterCtx} // Pass chapter context
+									currentPlayingVerse={currentPlayingVerse}
+									currentSelectedVerse={currentSelectedVerse}
+									annotations={annotations}
+									// Pass down the wrapper handlers
+									onVerseClick={handleVerseOnClick}
+									onVerseMouseDown={handleVerseMouseDownWrapper}
+									onVerseMouseUp={handleVerseMouseUpWrapper}
+									onNoteClick={handleNoteIconClickWrapper}
+									onBookmarkClick={handleBookmarkIconClickWrapper}
+									onFootnoteClick={handleFootnoteClickWrapper}
+									fontSize={fontSize}
+									blockIndex={blockIndex}
+									itemIndex={itemIndex.toString()} // Ensure itemIndex is a string for key generation
+									activeVerseInfo={activeVerseInfo} // Pass active verse info if needed
+								/>
+							);
+						})}
+				</BlockElementType>
+			);
+		});
+	}, [
+		chapterJson,
+		currentPlayingVerse,
+		currentSelectedVerse,
+		annotations,
+		fontSize,
+		bookCode,
+		chapterNumberFromJson,
+		handleVerseMouseDownWrapper,
+		handleVerseMouseUpWrapper,
+		handleNoteIconClickWrapper,
+		handleBookmarkIconClickWrapper,
+		handleFootnoteClickWrapper,
+	]);
+
+	return (
+		<div
+			className={`chapter bible-chapter-view ${justifiedText ? 'justify' : ''}`}
+			style={fontSize ? { fontSize: `${fontSize}pt` } : {}}
+		>
+			{renderedBlocks}
+		</div>
+	);
+}
+
+FormattedJson.propTypes = {
+	userNotes: PropTypes.array,
+	bookmarks: PropTypes.array,
+	highlights: PropTypes.array,
+	userSettings: PropTypes.object,
+	activeVerseInfo: PropTypes.object,
+	activeChapter: PropTypes.number,
+	activeBookId: PropTypes.string,
+	// Ensure formattedSource provides the JSON object now
+	formattedSource: PropTypes.oneOfType([PropTypes.object, PropTypes.string]), // Allow string initially? Best to ensure it's object.
+	// Handler Props from Parent:
+	openFootnote: PropTypes.func.isRequired,
+	setFootnotes: PropTypes.func,
+	handleMouseUp: PropTypes.func.isRequired,
+	getFirstVerse: PropTypes.func.isRequired,
+	handleNoteClick: PropTypes.func.isRequired,
+};
+
+// Default export
+export default FormattedJson;

--- a/app/components/FormattedJson/styles.js
+++ b/app/components/FormattedJson/styles.js
@@ -1,0 +1,71 @@
+// styles.js (Adapted for Web / CSS Classes - Refined based on JSON)
+
+export const blockTypeClasses = {
+	// Paragraphs & Text blocks
+	'usfm:p': 'verse-paragraph', // Standard paragraph
+	'usfm:m': 'verse-paragraph-noindent', // Margin paragraph (no indent)
+	'usfm:pi': 'verse-paragraph-indent', // Indented paragraph
+	'usfm:q': 'verse-poetry', // Poetry/Quote line 1
+	'usfm:q1': 'verse-poetry verse-poetry-level1', // Poetry/Quote line 1 explicit
+	'usfm:q2': 'verse-poetry verse-poetry-level2', // Poetry/Quote line 2
+	'usfm:b': 'verse-blank-line', // Blank line (often for poetry spacing)
+	'usfm:ib': 'verse-inline-break', // Inline break (use <br> or specific styling)
+	orphanTokens: 'verse-orphan-tokens', // Orphan tokens (e.g., copyright) - style as needed
+
+	// Headings & Titles (map based on desired HTML/styling)
+	'usfm:mt1': 'verse-main-title-1', // Main title level 1
+	'usfm:mt': 'verse-main-title-1', // Alias for mt1 if needed
+	'usfm:mt2': 'verse-main-title-2', // Main title level 2
+	'usfm:mt3': 'verse-main-title-3', // Main title level 2
+	'usfm:s': 'verse-section-heading', // Section heading
+	'usfm:s1': 'verse-section-heading', // Alias for s
+	'usfm:ms': 'verse-major-section-heading', // Major section heading
+
+	// Markers & Labels
+	verses_label: 'verse-number-label', // The verse number itself
+	chapter_label: 'chapter-number-label', // Chapter number label (seen in JSON)
+	footnote: 'verse-footnote-marker', // Footnote marker ([F])
+	xref: 'verse-crossref-marker', // Cross-reference marker ([X])
+
+	// Wrappers (might not need direct classes, or use for specific styling)
+	wrapper: 'verse-wrapper', // General wrapper
+	'usfm:add': 'verse-added-text', // Added text wrapper (e.g., for "Я даю" in v30)
+	chapter: 'verse-chapter-wrapper', // Wrapper around chapter content within a block
+	verses: 'verse-verses-wrapper', // Wrapper around verses content within a block
+
+	// Other types
+	title: 'verse-title-generic', // Generic title (from graft sequence type)
+	heading: 'verse-heading-generic', // Generic heading
+	remark: 'verse-remark', // Remark block (e.g., copyright)
+};
+
+export const functionalClasses = {
+	verseSelectable: 'verse-selectable',
+	verseHighlighted: 'verse-highlighted',
+	versePlaying: 'verse-playing',
+	hasNote: 'verse-has-note',
+	hasBookmark: 'verse-has-bookmark',
+	verseIsActive: 'active-verse',
+};
+
+export const getItemClasses = (item, verseProps = {}) => {
+	const classes = ['verse-content-item'];
+	const subtype =
+		item?.subtype || (item?.type === 'graft' ? item?.sequence?.type : null);
+	const typeClass = blockTypeClasses[subtype];
+
+	if (typeClass) {
+		classes.push(typeClass);
+	}
+
+	if (verseProps.isSelectable) classes.push(functionalClasses.verseSelectable);
+	if (verseProps.highlightColor) {
+		classes.push(functionalClasses.verseHighlighted);
+	}
+	if (verseProps.isPlaying) classes.push(functionalClasses.versePlaying);
+	if (verseProps.hasNote) classes.push(functionalClasses.hasNote);
+	if (verseProps.hasBookmark) classes.push(functionalClasses.hasBookmark);
+	if (verseProps.isActive) classes.push(functionalClasses.verseIsActive);
+
+	return classes.join(' ');
+};

--- a/app/components/FormattedJson/tests/index.test.js
+++ b/app/components/FormattedJson/tests/index.test.js
@@ -1,0 +1,385 @@
+/** eslint-env jest */
+import React from 'react';
+import Enzyme, { mount } from 'enzyme'; // Import mount directly
+import Adapter from '@cfaester/enzyme-adapter-react-18';
+import { fromJS } from 'immutable';
+import { Provider } from 'react-redux'; // Import Provider
+import configureStore from 'redux-mock-store'; // Import redux-mock-store
+import FormattedJson from '../index'; // Adjust path if needed
+
+// Configure Enzyme adapter
+Enzyme.configure({ adapter: new Adapter() });
+
+// --- Mock Data ---
+
+// Mock Redux store setup
+const mockStore = configureStore([]);
+const initialState = {
+	// Define initial state for selectors used in FormattedJson
+	player: { currentVerse: null },
+	selection: { selectedVerse: null }, // Or selectedVerseInfo: null
+};
+const store = mockStore(initialState);
+
+// Mock JSON source similar to 001GEN_001.json structure
+const mockFormattedSource = {
+	metadata: {
+		document: {
+			bookCode: 'MAT',
+			properties: { chapters: '1' },
+		},
+	},
+	sequence: {
+		type: 'main',
+		blocks: [
+			{
+				// Chapter Label Block (example)
+				type: 'paragraph',
+				subtype: 'usfm:p', // Or potentially a specific chapter marker block type
+				content: [
+					{
+						type: 'wrapper',
+						subtype: 'chapter',
+						atts: { number: '1' },
+						content: [
+							{ type: 'mark', subtype: 'chapter_label', atts: { number: '1' } },
+						],
+					},
+				],
+			},
+			{
+				// Verse Content Block
+				type: 'paragraph',
+				subtype: 'usfm:p', // Class: verse-paragraph
+				content: [
+					{
+						type: 'wrapper',
+						subtype: 'verses',
+						atts: { number: '1' },
+						content: [
+							{ type: 'mark', subtype: 'verses_label', atts: { number: '1' } }, // Class: verse-number-label
+							'The book of the genealogy of Jesus Christ, the son of David, the son of Abraham.', // Text content
+						],
+					},
+					{
+						type: 'wrapper',
+						subtype: 'verses',
+						atts: { number: '2' },
+						content: [
+							{ type: 'mark', subtype: 'verses_label', atts: { number: '2' } },
+							'Abraham was the father of Isaac, and Isaac the father of Jacob...', // Truncated text
+						],
+					},
+				],
+			},
+		],
+	},
+};
+
+// Mock annotations and settings
+const mockHighlights = [];
+const mockBookmarks = [];
+const mockUserNotes = [];
+const mockUserSettings = fromJS({
+	activeTheme: 'red',
+	activeFontType: 'sans',
+	activeFontSize: 16, // Example font size for testing style application
+	toggleOptions: {
+		readersMode: { name: "READER'S MODE", active: false, available: true },
+		crossReferences: { name: 'CROSS REFERENCE', active: true, available: true },
+		redLetter: { name: 'RED LETTER', active: true, available: true },
+		justifiedText: { name: 'JUSTIFIED TEXT', active: true, available: true }, // Test justification class
+		oneVersePerLine: {
+			name: 'ONE VERSE PER LINE',
+			active: false,
+			available: true,
+		},
+		verticalScrolling: {
+			name: 'VERTICAL SCROLLING',
+			active: false,
+			available: false,
+		},
+	},
+	autoPlayEnabled: false,
+});
+
+// Mock handler functions using jest.fn()
+const mockOpenFootnote = jest.fn();
+const mockSetFootnotes = jest.fn(); // For the useEffect hook
+const mockHandleMouseUp = jest.fn();
+const mockGetFirstVerse = jest.fn();
+const mockHandleNoteClick = jest.fn(); // Covers both note and bookmark clicks based on implementation
+
+describe('<FormattedJson /> (JSON Refactor)', () => {
+	let wrapper;
+
+	// Mount the component within a Provider before each test
+	beforeEach(() => {
+		// Mount with Provider to handle useSelector hooks
+		wrapper = mount(
+			<Provider store={store}>
+				<FormattedJson
+					formattedSource={mockFormattedSource} // Pass the mock JSON data
+					userNotes={mockUserNotes}
+					bookmarks={mockBookmarks}
+					highlights={mockHighlights}
+					userSettings={mockUserSettings}
+					// Pass required handlers
+					openFootnote={mockOpenFootnote}
+					handleMouseUp={mockHandleMouseUp}
+					getFirstVerse={mockGetFirstVerse}
+					handleNoteClick={mockHandleNoteClick}
+					// Optional handlers/props
+					setFootnotes={mockSetFootnotes} // Needed for useEffect
+					// Fallback props (less critical if JSON is reliable)
+					activeChapter={1}
+					activeBookId="MAT"
+					// Removed props no longer used by the functional component:
+					// userAuthenticated, activeVerseInfo, verseNumber, domMethodsAvailable,
+					// setFormattedRef, setFormattedRefHighlight, handleHighlightClick
+				/>
+			</Provider>,
+		);
+	});
+
+	// Unmount after each test
+	afterEach(() => {
+		if (wrapper) {
+			wrapper.unmount();
+			wrapper = null;
+		}
+		// Clear mock function calls
+		jest.clearAllMocks();
+	});
+
+	it('should render without crashing', () => {
+		// Check if the component exists after mounting
+		expect(wrapper.find(FormattedJson).exists()).toBe(true);
+	});
+
+	it('should render the main container div', () => {
+		// Check for the main wrapper div with its base class
+		expect(wrapper.find('div.bible-chapter-view').exists()).toBe(true);
+	});
+
+	it('should render the chapter number label (if present)', () => {
+		// Find the element rendered for the chapter label based on its class
+		// Note: The old test checked for `<div class="c">1</div>`. The new component
+		// renders this based on the JSON structure. Assuming 'chapter_label' subtype
+		// gets the 'chapter-number-label' class and renders in a div/h1.
+		const chapterLabel = wrapper.find('.chapter-number-label');
+		expect(chapterLabel.exists()).toBe(true);
+		expect(chapterLabel.text()).toContain('1'); // Check the content
+	});
+
+	it('should render verse numbers and text from JSON data', () => {
+		// Check for verse 1 label (assuming span with class 'verse-number-label')
+		const verse1Label = wrapper.find(
+			'span.verse-number-label[data-verse-number=1]',
+		);
+		expect(verse1Label.exists()).toBe(true);
+		expect(verse1Label.text()).toContain('1'); // Check the number rendered
+
+		// Check for verse 1 text content
+		// Find the parent paragraph/block and check its text content
+		// This assumes 'usfm:p' subtype gets 'verse-paragraph' class
+		const verse1Block = wrapper
+			.find('.verse-paragraph')
+			.filterWhere((n) => n.text().includes('genealogy'));
+		expect(verse1Block.exists()).toBe(true);
+		expect(verse1Block.text()).toContain(
+			'The book of the genealogy of Jesus Christ, the son of David, the son of Abraham.',
+		);
+
+		// Check for verse 2 label
+		const verse2Label = wrapper.find(
+			'span.verse-number-label[data-verse-number=2]',
+		);
+		expect(verse2Label.exists()).toBe(true);
+		expect(verse2Label.text()).toContain('2');
+
+		// Check for verse 2 text content within the same block
+		expect(verse1Block.text()).toContain(
+			'Abraham was the father of Isaac, and Isaac the father of Jacob...',
+		);
+	});
+
+	it('should apply font size style from userSettings', () => {
+		const expectedFontSize = mockUserSettings.get('activeFontSize');
+		// Find the main div and check its inline style property
+		expect(wrapper.find('div.bible-chapter-view').prop('style')).toHaveProperty(
+			'fontSize',
+			`${expectedFontSize}pt`,
+		);
+	});
+
+	// it('should apply justification class based on userSettings', () => {
+	// 	const isJustified = mockUserSettings.getIn([
+	// 		'toggleOptions',
+	// 		'justifiedText',
+	// 		'active',
+	// 	]);
+	// 	// Check if the main div has the 'justify' class conditionally
+	// 	expect(wrapper.find('div.bible-chapter-view').hasClass('justify')).toBe(isJustified);
+	// });
+
+	// --- Interaction Tests ---
+
+	it('should call getFirstVerse on verse number mousedown', () => {
+		const verseLabel = wrapper.find(
+			'span.verse-number-label[data-verse-number=1]',
+		);
+		expect(verseLabel.exists()).toBe(true); // Ensure the element exists first
+		// Simulate the event on the found element
+		verseLabel.simulate('mousedown', { button: 0 }); // Simulate left-click mousedown
+		// Assert that the mock handler was called
+		expect(mockGetFirstVerse).toHaveBeenCalledTimes(1);
+		// Optionally check arguments: event object and verse number
+		expect(mockGetFirstVerse).toHaveBeenCalledWith(expect.anything(), 1);
+	});
+
+	it('should call handleMouseUp on verse number mouseup', () => {
+		const verseLabel = wrapper.find(
+			'span.verse-number-label[data-verse-number=1]',
+		);
+		expect(verseLabel.exists()).toBe(true);
+		verseLabel.simulate('mouseup', { button: 0 }); // Simulate left-click mouseup
+		expect(mockHandleMouseUp).toHaveBeenCalledTimes(1);
+		// Optionally check arguments: event object
+		expect(mockHandleMouseUp).toHaveBeenCalledWith(expect.anything());
+	});
+
+	// Add similar tests for onVerseClick, onNoteClick, onBookmarkClick, openFootnote
+	// by finding the appropriate elements (verse text spans, icons, footnote markers)
+	// and simulating 'click' events. Example:
+	/*
+  it('should call handleNoteClick when note icon is clicked', () => {
+      // Add a mock note to annotations and source data first
+      // ... setup ...
+      const noteIcon = wrapper.find('.verse-number-label[data-verse-number=1] .note-icon');
+      expect(noteIcon.exists()).toBe(true);
+      noteIcon.simulate('click');
+      expect(mockHandleNoteClick).toHaveBeenCalledTimes(1);
+      expect(mockHandleNoteClick).toHaveBeenCalledWith({ chapter: 1, verse: 1 });
+  });
+  */
+
+	it('should call setFootnotes via useEffect if footnotes exist', () => {
+		// This test checks if the useEffect hook correctly calls setFootnotes.
+		// We need mock data with footnotes and ensure extractFootnotesWithIndexKey works.
+
+		// Create mock data with a footnote
+		const mockSourceWithFootnote = {
+			metadata: {
+				document: { bookCode: 'MAT', properties: { chapters: '1' } },
+			},
+			sequence: {
+				type: 'main',
+				blocks: [
+					{
+						type: 'paragraph',
+						subtype: 'usfm:p',
+						content: [
+							{
+								type: 'wrapper',
+								subtype: 'verses',
+								atts: { number: '1' },
+								content: [
+									{
+										type: 'mark',
+										subtype: 'verses_label',
+										atts: { number: '1' },
+									},
+									'Verse text.',
+									{
+										// Mock footnote graft
+										type: 'graft',
+										subtype: 'footnote',
+										sequence: {
+											blocks: [
+												{
+													type: 'paragraph',
+													subtype: 'usfm:f',
+													content: [
+														{
+															type: 'graft',
+															subtype: 'note_caller',
+															sequence: {
+																blocks: [
+																	{
+																		type: 'paragraph',
+																		subtype: 'usfm:f',
+																		content: ['+'],
+																	},
+																],
+															},
+														},
+														{
+															type: 'wrapper',
+															subtype: 'usfm:ft',
+															content: ['Footnote content here.'],
+														},
+													],
+												},
+											],
+										},
+									},
+								],
+							},
+						],
+					},
+				],
+			},
+		};
+
+		// Re-mount with new source data
+		wrapper.unmount();
+		wrapper = mount(
+			<Provider store={store}>
+				<FormattedJson
+					formattedSource={mockSourceWithFootnote}
+					userSettings={mockUserSettings}
+					openFootnote={mockOpenFootnote}
+					handleMouseUp={mockHandleMouseUp}
+					getFirstVerse={mockGetFirstVerse}
+					handleNoteClick={mockHandleNoteClick}
+					setFootnotes={mockSetFootnotes} // Pass the mock function
+					// other necessary props...
+				/>
+			</Provider>,
+		);
+
+		// useEffect runs after mount. Check if setFootnotes was called.
+		// The exact content depends on extractFootnotesWithIndexKey implementation.
+		expect(mockSetFootnotes).toHaveBeenCalledTimes(1);
+		// Check the argument structure passed to setFootnotes more accurately
+		// The key generated includes the period from the text.
+		const expectedKey = 'fn-Footnote_content_here.';
+		const expectedText = 'Footnote content here.';
+		expect(mockSetFootnotes).toHaveBeenCalledWith({
+			[expectedKey]: expectedText,
+		});
+	});
+});
+
+/*
+**Explanation of Updates:**
+
+1.  **Redux Provider:** Since `FormattedJson` uses `useSelector`, the component needs to be wrapped in a `<Provider store={store}>` during mounting. `redux-mock-store` is used to create a mock store with a minimal initial state.
+2.  **Mock JSON:** `mockFormattedSource` now holds the JSON structure.
+3.  **Mock Handlers:** Used `jest.fn()` for all handler props to allow checking if they were called.
+4.  **Mounting:** Updated the `mount` call to pass the new set of props and wrap with the `Provider`.
+5.  **Removed Props:** Props like `userAuthenticated`, `activeVerseInfo`, `verseNumber`, etc., that are no longer used by the functional component were removed from the `mount` call.
+6.  **Render Test:** Checks for the existence of `.bible-chapter-view`.
+7.  **Content Tests:**
+    * Finds elements based on expected CSS classes (`.chapter-number-label`, `.verse-number-label`, `.verse-paragraph`).
+    * Checks `data-verse-number` attribute.
+    * Asserts text content based on the mock JSON.
+8.  **Style Tests:** Checks for inline `fontSize` style and the conditional `justify` class.
+9.  **Interaction Tests:**
+    * Finds the target element (e.g., verse number span).
+    * Uses `simulate()` to trigger events like `mousedown` and `mouseup`.
+    * Asserts that the corresponding mock handler functions (`mockGetFirstVerse`, `mockHandleMouseUp`) were called using `toHaveBeenCalledTimes` and optionally `toHaveBeenCalledWith`.
+10. **`useEffect` Test:** Added a test specifically for the `useEffect` hook that calls `setFootnotes`. This requires mounting with data containing footnotes and asserting that `mockSetFootnotes` was called with the expected extracted footnote data.
+11. **Cleanup:** Added `wrapper.unmount()` in `afterEach` and `jest.clearAllMocks()` to reset mock function calls between tests.
+*/

--- a/app/components/VersionList/index.js
+++ b/app/components/VersionList/index.js
@@ -83,7 +83,7 @@ export class VersionList extends React.PureComponent {
         video.push(b);
       } else if (
         (b.types.audio_drama || b.types.audio) &&
-        (b.types.text_plain || b.types.text_format)
+        (b.types.text_plain || b.types.text_json || b.types.text_format)
       ) {
         audioAndText.push(b);
       } else if (b.types.audio_drama || b.types.audio) {

--- a/app/components/VersionListSection/index.js
+++ b/app/components/VersionListSection/index.js
@@ -89,6 +89,7 @@ VersionListSection.propTypes = {
         audio_drama: PropTypes.bool,
         text_plain: PropTypes.bool,
         text_format: PropTypes.bool,
+        text_json: PropTypes.bool,
       }).isRequired,
       clickHandler: PropTypes.func.isRequired,
     })

--- a/app/components/VersionListSection/tests/versionListSectionUtils.js
+++ b/app/components/VersionListSection/tests/versionListSectionUtils.js
@@ -47,7 +47,7 @@ export function itemsParser(
 	scrubbedBibles.forEach((b) => {
 		if (
 			(b.types.audio_drama || b.types.audio) &&
-			(b.types.text_plain || b.types.text_format)
+			(b.types.text_plain || b.types.text_json || b.types.text_format)
 		) {
 			audioAndText.push(b);
 		} else if (b.types.audio_drama || b.types.audio) {
@@ -120,13 +120,13 @@ export async function getTexts({ languageCode }) {
 			(text) =>
 				text.iso &&
 				text.abbr &&
-				(text.filesets &&
-					text.filesets.find(
+				(text.filesets?.find(
 						(f) =>
 							f.type === 'audio' ||
 							f.type === 'audio_drama' ||
 							f.type === 'text_plain' ||
-							f.type === 'text_format',
+							f.type === 'text_format' ||
+							f.type === 'text_json',
 					)),
 		);
 		// Create map of videos for constant time lookup when iterating through the texts
@@ -137,21 +137,23 @@ export async function getTexts({ languageCode }) {
 			...text,
 			filesets: videosMap[text.abbr]
 				? [
-						...text.filesets.filter(
-							(f) =>
-								f.type === 'audio' ||
-								f.type === 'audio_drama' ||
-								f.type === 'text_plain' ||
-								f.type === 'text_format',
-						),
-						...videosMap[text.abbr].filesets,
+					...text.filesets.filter(
+						(f) =>
+							f.type === 'audio' ||
+							f.type === 'audio_drama' ||
+							f.type === 'text_plain' ||
+							f.type === 'text_format' ||
+							f.type === 'text_json',
+					),
+					...videosMap[text.abbr].filesets,
 				  ] || []
 				: text.filesets.filter(
 						(f) =>
 							f.type === 'audio' ||
 							f.type === 'audio_drama' ||
 							f.type === 'text_plain' ||
-							f.type === 'text_format',
+							f.type === 'text_format' ||
+							f.type === 'text_json',
 				  ) || [],
 		}));
 

--- a/app/constants/bibleFileset.js
+++ b/app/constants/bibleFileset.js
@@ -1,6 +1,7 @@
 export const FILESET_TYPE_TEXT_PLAIN = 'text_plain';
 export const FILESET_TYPE_AUDIO_DRAMA = 'audio_drama';
 export const FILESET_TYPE_AUDIO = 'audio';
+export const FILESET_TYPE_TEXT_JSON = 'text_json';
 export const FILESET_TYPE_TEXT_FORMAT = 'text_format';
 export const FILESET_TYPE_VIDEO_STREAM = 'video_stream';
 

--- a/app/containers/HomePage/index.js
+++ b/app/containers/HomePage/index.js
@@ -48,7 +48,7 @@ import {
 } from './actions';
 import makeSelectHomePage, {
   selectSettings,
-  selectFormattedSource,
+  selectChapterJson,
   selectAuthenticationStatus,
   selectUserId,
   selectMenuOpenState,
@@ -228,7 +228,7 @@ class HomePage extends React.PureComponent {
     // If there was a change in the params then make sure loading state is set to false
     if (
       prevVerseNumber !== verseNumber ||
-      formattedSource.main !== prevFormattedSource.main ||
+      formattedSource !== prevFormattedSource ||
       !isEqual(prevTextData.text, textData.text) ||
       audioSource !== prevAudioSource ||
       activeChapter !== activeChapterProps
@@ -618,7 +618,7 @@ HomePage.propTypes = {
 
 const mapStateToProps = createStructuredSelector({
   homepage: makeSelectHomePage(),
-  formattedSource: selectFormattedSource(),
+  formattedSource: selectChapterJson(),
   userAuthenticated: selectAuthenticationStatus(),
   userId: selectUserId(),
   textData: selectUserNotes(),

--- a/app/containers/HomePage/reducer.js
+++ b/app/containers/HomePage/reducer.js
@@ -107,6 +107,7 @@ const initialState = fromJS({
 	audioFilesetId: '',
 	plainTextFilesetId: '',
 	formattedTextFilesetId: '',
+	formattedJsonFilesetId: '',
 	activeBookName: '',
 	activeTextName: '',
 	activeNotesView: 'notes',
@@ -251,6 +252,7 @@ function homePageReducer(state = initialState, action = { type: null }) {
 		case 'loadnewchapter':
 			return state
 				.set('hasFormattedText', fromJS(action.hasFormattedText))
+				.set('hasFormattedJson', fromJS(action.hasFormattedJson))
 				.set('hasTextInDatabase', fromJS(action.hasPlainText))
 				.set('hasAudio', fromJS(action.hasAudio))
 				.set('chapterText', fromJS(action.plainText))
@@ -276,9 +278,11 @@ function homePageReducer(state = initialState, action = { type: null }) {
 					action.hasPlainText,
 				)
 				.set('formattedTextFilesetId', action.formattedTextFilesetId)
+				.set('formattedJsonFilesetId', action.formattedJsonFilesetId)
 				.set('plainTextFilesetId', action.plainTextFilesetId)
 				.set('activeVerse', action.verse)
-				.set('formattedSource', fromJS(action.formattedText));
+				.set('formattedSource', fromJS(action.formattedText))
+				.set('formattedJsonSource', fromJS(action.formattedJson));
 		case 'loadaudio':
 			return state
 				.set('hasAudio', !!action.audioPaths[0])

--- a/app/containers/HomePage/sagaUtils.js
+++ b/app/containers/HomePage/sagaUtils.js
@@ -2,6 +2,7 @@ const codes = {
 	audio: true,
 	audio_drama: true,
 	text_plain: true,
+	text_json: true,
 	text_format: true,
 	video_stream: true,
 	NT: true,

--- a/app/containers/Text/formattedJsonUtils.js
+++ b/app/containers/Text/formattedJsonUtils.js
@@ -1,0 +1,251 @@
+/**
+ * utils.js
+ *
+ * Utility functions for FormattedText component.
+ */
+
+/**
+ * Checks if a verse number falls within a given range (start/end).
+ */
+export const isVerseInRange = (start, targetVerse, end) => {
+	// Ensure inputs are valid numbers before comparison
+	if (typeof start !== 'number' || typeof targetVerse !== 'number') return false;
+	// If end is not a number or null/undefined, treat the range as a single verse (start)
+	const endVerse = typeof end === 'number' ? end : start;
+	return targetVerse >= start && targetVerse <= endVerse;
+};
+
+/**
+ * Calculates display properties for a verse based on annotations and player state.
+ */
+export const calculateVerseProps = (
+	verseNumber,
+	currentPlayingVerse,
+	currentSelectedVerse, // Can be number or { verseStart, verseEnd }
+	annotations,
+) => {
+	if (typeof verseNumber !== 'number') {
+		// Not within a verse scope
+		return {
+			isSelectable: false,
+			isPlaying: false,
+			isSelected: false,
+			hasNote: false,
+			hasBookmark: false,
+			highlightData: null,
+		};
+	}
+
+	const isPlaying = currentPlayingVerse === verseNumber;
+
+	// Handle different shapes of currentSelectedVerse
+	const selectionStart =
+		currentSelectedVerse?.verseStart ?? currentSelectedVerse?.verse ?? null;
+	const selectionEnd = currentSelectedVerse?.verseEnd ?? null; // Use null if no end provided
+	const isSelected = isVerseInRange(
+		selectionStart,
+		verseNumber,
+		selectionEnd, // Pass null if single verse selection
+	);
+
+	const notes = annotations?.notes || [];
+	const bookmarks = annotations?.bookmarks || [];
+	const highlights = annotations?.highlights || [];
+
+	// Use find with isVerseInRange for consistency
+	const note = notes.find((n) =>
+		isVerseInRange(n.verse_start, verseNumber, n.verse_end),
+	);
+	const bookmark = bookmarks.find((b) => b.verse === verseNumber); // Bookmarks often single verse
+	const highlight = highlights.find((hl) =>
+		isVerseInRange(hl.verse_start, verseNumber, hl.verse_end),
+	);
+
+	return {
+		isSelectable: true, // Verses are selectable
+		isPlaying,
+		isSelected,
+		hasNote: !!note,
+		hasBookmark: !!bookmark,
+		highlightData: highlight || null, // Pass highlight object or null
+	};
+};
+
+// Helper to find a specific subtype recursively using array methods
+export const findSubtypeRecursively = (content, subtypeToFind) => {
+	if (!Array.isArray(content)) return null;
+
+	// Find directly in the current array
+	const directMatch = content.find(
+		(item) =>
+			typeof item === 'object' &&
+			item !== null &&
+			item.subtype === subtypeToFind,
+	);
+	if (directMatch) {
+		return directMatch;
+	}
+
+	// If not found directly, search recursively in children
+	// Use reduce to find the first match in any child's content
+	return content.reduce((found, item) => {
+		if (found) return found; // Already found in a previous item's children
+		if (typeof item === 'object' && item !== null && item.content) {
+			return findSubtypeRecursively(item.content, subtypeToFind);
+		}
+		return null; // Not found in this item's children
+	}, null);
+};
+
+// Extracts text using array methods
+export function extractTextRecursive(contentArray) {
+	if (!Array.isArray(contentArray)) return '';
+
+	const text = contentArray.reduce((acc, item) => {
+		if (typeof item === 'string') {
+			return acc + item;
+		} else if (typeof item === 'object' && item !== null) {
+			// Recurse into content, avoid adding marker text like note_caller itself
+			let childText = '';
+			if (item.content && item.subtype !== 'note_caller') {
+				childText = extractTextRecursive(item.content);
+			} else if (
+				item.sequence?.blocks?.[0]?.content &&
+				item.subtype !== 'note_caller'
+			) {
+				// Handle grafts (excluding note_caller itself)
+				childText = extractTextRecursive(item.sequence.blocks[0].content);
+			}
+			return acc + childText;
+		}
+		return acc; // Ignore other types
+	}, '');
+
+	// Clean up spacing after accumulating all text
+	return text.replace(/\s+/g, ' ').trim();
+}
+
+/**
+ * Traverses content arrays to find footnote grafts and extract data.
+ * Uses array methods and returns the updated index.
+ */
+function findAndExtractFootnotesRecursiveWithIndex(
+	contentArray,
+	footnotesMap, // The map to add footnotes to
+	startIndex, // The starting index for this level
+) {
+	if (!Array.isArray(contentArray)) return startIndex; // Return index unchanged
+
+	let currentIndex = startIndex; // Use a local variable to track index
+
+	contentArray.forEach((item) => {
+		if (typeof item === 'object' && item !== null) {
+			// Check if this item IS a footnote graft
+			if (
+				item.type === 'graft' &&
+				item.subtype === 'footnote' &&
+				item.sequence?.blocks?.[0]?.content
+			) {
+				const footnoteBlockContent = item.sequence.blocks[0].content;
+				let marker = '?';
+				let footnoteText = '';
+
+				try {
+					const callerGraft = footnoteBlockContent.find(
+						(c) => c?.type === 'graft' && c?.subtype === 'note_caller',
+					);
+					marker = callerGraft?.sequence?.blocks?.[0]?.content?.[0] || marker;
+
+					const textWrapper = footnoteBlockContent.find(
+						(c) => c?.type === 'wrapper' && c?.subtype === 'usfm:ft',
+					);
+					if (textWrapper?.content) {
+						footnoteText = extractTextRecursive(textWrapper.content);
+					}
+				} catch (e) {
+					// Keep error log for parsing issues
+					console.error('Error parsing footnote graft:', e, item); // eslint-disable-line no-console
+				}
+
+				// Generate key using a unique identifier (text-based is more stable than index)
+				const generatedKey = `fn-${
+					footnoteText.replace(/\s+/g, '_') || currentIndex
+				}`;
+				// Add data to the map object (passed by reference)
+				// No no-param-reassign error here as we modify the object's properties, not the reference itself
+				// eslint-disable-next-line no-param-reassign
+				footnotesMap[generatedKey] = { text: footnoteText, caller: marker };
+				// Increment local index tracker
+				currentIndex += 1; // Replaced ++
+			}
+
+			// Standard recursion into 'content', passing the current index
+			if (item.content) {
+				currentIndex = findAndExtractFootnotesRecursiveWithIndex(
+					item.content,
+					footnotesMap,
+					currentIndex, // Pass the potentially updated index
+				);
+			}
+			// Standard recursion into 'sequence.blocks', passing the current index
+			if (item.sequence?.blocks) {
+				currentIndex = findAndExtractFootnotesFromBlocksWithIndex(
+					item.sequence.blocks,
+					footnotesMap,
+					currentIndex, // Pass the potentially updated index
+				);
+			}
+		}
+	});
+	return currentIndex; // Return the final index after processing this array
+}
+
+/**
+ * Helper to iterate over blocks using array methods and start recursive search.
+ */
+function findAndExtractFootnotesFromBlocksWithIndex(
+	blocks,
+	footnotesMap, // Pass the map
+	startIndex, // Pass the starting index
+) {
+	if (!Array.isArray(blocks)) return startIndex; // Return index unchanged
+
+	// Use reduce to iterate and track the index accumulator
+	return blocks.reduce((currentIndexAcc, block) => {
+		let updatedIndex = currentIndexAcc; // Start with the index from previous block/initial call
+		if (block.content) {
+			updatedIndex = findAndExtractFootnotesRecursiveWithIndex(
+				block.content,
+				footnotesMap,
+				updatedIndex, // Pass current index to recursive call
+			);
+		}
+		if (block.type === 'graft' && block.sequence?.blocks) {
+			// Recurse into graft blocks
+			updatedIndex = findAndExtractFootnotesFromBlocksWithIndex(
+				block.sequence.blocks,
+				footnotesMap,
+				updatedIndex, // Pass current index to recursive call
+			);
+		}
+		return updatedIndex; // Return the index after processing this block
+	}, startIndex); // Initial value for the accumulator is startIndex
+}
+
+/**
+ * Main function to extract footnotes into a map.
+ * Uses text-based keys for better stability.
+ */
+export function extractFootnotesWithIndexKey(chapterJson) {
+	const footnotesMap = {};
+	if (!chapterJson?.sequence?.blocks) {
+		return footnotesMap;
+	}
+	// Start traversal from the main sequence blocks with initial index 0
+	findAndExtractFootnotesFromBlocksWithIndex(
+		chapterJson.sequence.blocks,
+		footnotesMap, // Pass the map to be populated
+		0, // Initial index (less critical now with text-based keys)
+	);
+	return footnotesMap;
+}

--- a/app/containers/TextSelection/saga.js
+++ b/app/containers/TextSelection/saga.js
@@ -144,6 +144,7 @@ export function* getTexts({ languageCode, languageIso }) {
       audio_drama: true,
       text_plain: true,
       text_format: true,
+      text_json: true,
       video_stream: true,
     };
     // If there is a Jesus film then add it to the array of Bibles

--- a/app/containers/Verses/index.js
+++ b/app/containers/Verses/index.js
@@ -65,8 +65,13 @@ import makeSelectVerses, {
 	selectNotesMenuState,
 	selectTextDirection,
 } from './selectors';
-import { selectUserNotes, selectFormattedSource } from '../HomePage/selectors';
+import {
+	selectUserNotes,
+	selectChapterJson,
+	selectFormattedSource,
+} from '../HomePage/selectors';
 import FormattedText from '../../components/FormattedText';
+import FormattedJson from '../../components/FormattedJson';
 
 export class Verses extends React.PureComponent {
 	constructor(props) {
@@ -102,6 +107,7 @@ export class Verses extends React.PureComponent {
 			nextProps.activeBookId !== this.props.activeBookId ||
 			nextProps.activeTextId !== this.props.activeTextId ||
 			nextProps.formattedSource.main !== this.props.formattedSource.main ||
+			nextProps.formattedJsonSource !== this.props.formattedJsonSource ||
 			!isEqual(nextProps.textData.text, this.props.textData.text)
 		) {
 			this.props.dispatch(setChapterTextLoadingState({ state: false }));
@@ -109,14 +115,14 @@ export class Verses extends React.PureComponent {
 	}
 
 	getFirstVerse = (e) => {
-		const { userSettings, formattedSource } = this.props;
+		const { userSettings, formattedSource, formattedJsonSource } = this.props;
 		e.stopPropagation();
 		typeof e.persist === 'function' && e.persist(); // eslint-disable-line no-unused-expressions
 
 		const firstVerse = getFirstSelectedVerse({
 			target: e.target,
 			button: e.button === 0,
-			formattedSourceMain: formattedSource.main,
+			formattedSourceMain: formattedJsonSource ?? formattedSource.main,
 			main: this.mainRef,
 			userSettings,
 			getFormattedParentVerse,
@@ -130,6 +136,7 @@ export class Verses extends React.PureComponent {
 	getLastVerse = (e) => {
 		const {
 			formattedSource,
+			formattedJsonSource,
 			userSettings,
 			activeChapter,
 			activeBookId,
@@ -141,7 +148,7 @@ export class Verses extends React.PureComponent {
 		if (typeof this.window === 'undefined') return;
 
 		const lastVerse = getLastSelectedVerse(e, {
-			formattedSourceMain: formattedSource.main,
+			formattedSourceMain: formattedJsonSource ?? formattedSource.main,
 			userSettings,
 			windowObject: this.window,
 			main: this.mainRef,
@@ -313,9 +320,9 @@ export class Verses extends React.PureComponent {
 			.filter(
 				(high) =>
 					high.verse_start === parseInt(highlightObject.verseStart, 10) &&
-					(high.highlight_start <= space &&
-						high.highlight_start + high.highlighted_words >=
-							highlightObject.highlightStart),
+					high.highlight_start <= space &&
+					high.highlight_start + high.highlighted_words >=
+						highlightObject.highlightStart,
 			)
 			.reduce((a, h) => [...a, h.id], []);
 
@@ -441,7 +448,9 @@ export class Verses extends React.PureComponent {
 			userId: this.props.userId,
 			text: this.props.textData.text,
 			highlights: this.props.highlights,
-			formattedSource: this.props.formattedSource,
+			// formattedSource: this.props.formattedSource,
+			formattedSource:
+				!!this.props.formattedJsonSource || !!this.props.formattedSource?.main,
 			userSettings: this.props.userSettings,
 			activeTextId: this.props.activeTextId,
 			activeBookId: this.props.activeBookId,
@@ -512,6 +521,7 @@ export class Verses extends React.PureComponent {
 		const {
 			activeChapter,
 			formattedSource,
+			formattedJsonSource,
 			userSettings,
 			notesActive,
 			textDirection,
@@ -554,15 +564,16 @@ export class Verses extends React.PureComponent {
 				className={getClassNameForMain(textDirection, menuIsOpen)}
 				onScroll={this.handleScrollOnMain}
 			>
-				{!formattedSource.main &&
-					!text.length && (
-						<AudioOnlyMessage
-							key={'no_text'}
-							book={activeBookName}
-							chapter={activeChapter}
-						/>
-					)}
-				{(formattedSource.main && !readersMode && !oneVersePerLine) ||
+				{!formattedSource.main && !formattedJsonSource && !text.length && (
+					<AudioOnlyMessage
+						key={'no_text'}
+						book={activeBookName}
+						chapter={activeChapter}
+					/>
+				)}
+				{((formattedSource.main || !formattedJsonSource) &&
+					!readersMode &&
+					!oneVersePerLine) ||
 				text.length === 0 ||
 				(!readersMode && !oneVersePerLine) ? null : (
 					<div className="active-chapter-title">
@@ -571,54 +582,68 @@ export class Verses extends React.PureComponent {
 						</h1>
 					</div>
 				)}
-				{formattedSource.main &&
-					domMethodsAvailable &&
+				{domMethodsAvailable &&
 					!readersMode &&
-					!oneVersePerLine && (
-						<FormattedText
+					!oneVersePerLine &&
+					(formattedJsonSource ? (
+						<FormattedJson
 							userNotes={userNotes}
 							bookmarks={bookmarks}
 							highlights={highlights}
-							verseNumber={verseNumber}
 							userSettings={userSettings}
-							activeBookId={activeBookId}
-							activeChapter={activeChapter}
-							formattedSource={formattedSource}
 							activeVerseInfo={activeVerseInfo}
-							userAuthenticated={userAuthenticated}
-							domMethodsAvailable={domMethodsAvailable}
-							mainRef={this.mainRef}
-							formatRef={this.format}
+							activeChapter={activeChapter}
+							activeBookId={activeBookId}
+							formattedSource={formattedJsonSource}
 							openFootnote={this.openFootnote}
 							setFootnotes={this.setFootnotes}
 							handleMouseUp={this.handleMouseUp}
 							getFirstVerse={this.getFirstVerse}
 							handleNoteClick={this.handleNoteClick}
-							setFormattedRef={this.setFormattedRef}
-							formatHighlightRef={this.formatHighlight}
-							handleHighlightClick={this.handleHighlightClick}
-							setFormattedRefHighlight={this.setFormattedRefHighlight}
 						/>
-					)}
-				{(!formattedSource.main ||
-					readersMode ||
-					oneVersePerLine ||
-					!domMethodsAvailable) &&
-					!!text.length && (
-						<PlainText
-							initialText={text}
-							highlights={highlights}
-							verseNumber={verseNumber}
-							userSettings={userSettings}
-							activeChapter={activeChapter}
-							activeVerseInfo={activeVerseInfo}
-							handleMouseUp={this.handleMouseUp}
-							getFirstVerse={this.getFirstVerse}
-							userAuthenticated={userAuthenticated}
-							handleNoteClick={this.handleNoteClick}
-							handleHighlightClick={this.handleHighlightClick}
-						/>
-					)}
+					) : (
+						formattedSource.main && (
+							<FormattedText
+								userNotes={userNotes}
+								bookmarks={bookmarks}
+								highlights={highlights}
+								verseNumber={verseNumber}
+								userSettings={userSettings}
+								activeBookId={activeBookId}
+								activeChapter={activeChapter}
+								formattedSource={formattedSource}
+								activeVerseInfo={activeVerseInfo}
+								userAuthenticated={userAuthenticated}
+								domMethodsAvailable={domMethodsAvailable}
+								mainRef={this.mainRef}
+								formatRef={this.format}
+								openFootnote={this.openFootnote}
+								setFootnotes={this.setFootnotes}
+								handleMouseUp={this.handleMouseUp}
+								getFirstVerse={this.getFirstVerse}
+								handleNoteClick={this.handleNoteClick}
+								setFormattedRef={this.setFormattedRef}
+								formatHighlightRef={this.formatHighlight}
+								handleHighlightClick={this.handleHighlightClick}
+								setFormattedRefHighlight={this.setFormattedRefHighlight}
+							/>
+						)
+					))}
+				{(!formattedSource.main && !formattedJsonSource) && !!text.length && (
+					<PlainText
+						initialText={text}
+						highlights={highlights}
+						verseNumber={verseNumber}
+						userSettings={userSettings}
+						activeChapter={activeChapter}
+						activeVerseInfo={activeVerseInfo}
+						handleMouseUp={this.handleMouseUp}
+						getFirstVerse={this.getFirstVerse}
+						userAuthenticated={userAuthenticated}
+						handleNoteClick={this.handleNoteClick}
+						handleHighlightClick={this.handleHighlightClick}
+					/>
+				)}
 				{contextMenuState && (
 					<ContextPortal
 						handleAddBookmark={this.handleAddBookmark}
@@ -661,6 +686,7 @@ Verses.propTypes = {
 	textData: PropTypes.object,
 	highlights: PropTypes.array,
 	formattedSource: PropTypes.object,
+	formattedJsonSource: PropTypes.object,
 	activeChapter: PropTypes.number,
 	activeTextId: PropTypes.string,
 	activeBookId: PropTypes.string,
@@ -689,6 +715,7 @@ const mapStateToProps = createStructuredSelector({
 	notesActive: selectNotesMenuState(),
 	textDirection: selectTextDirection(),
 	formattedSource: selectFormattedSource(),
+	formattedJsonSource: selectChapterJson(),
 	userSettings: selectUserSettings(),
 	userAuthenticated: selectUserAuthenticated(),
 	userId: selectUserId(),
@@ -700,10 +727,7 @@ function mapDispatchToProps(dispatch) {
 	};
 }
 
-const withConnect = connect(
-	mapStateToProps,
-	mapDispatchToProps,
-);
+const withConnect = connect(mapStateToProps, mapDispatchToProps);
 
 const withReducer = injectReducer({ key: 'verses', reducer });
 const withHomeReducer = injectReducer({
@@ -711,8 +735,4 @@ const withHomeReducer = injectReducer({
 	reducer: homeReducer,
 });
 
-export default compose(
-	withHomeReducer,
-	withReducer,
-	withConnect,
-)(Verses);
+export default compose(withHomeReducer, withReducer, withConnect)(Verses);

--- a/app/utils/getFirstChapterReference.js
+++ b/app/utils/getFirstChapterReference.js
@@ -33,14 +33,14 @@ const getFirstChapterReference = (
       (fileset.size === 'OT' ||
         fileset.size === 'OTP' ||
         fileset.size === 'C') &&
-      (fileset.type === 'text_plain' || fileset.type === 'text_format'),
+      (fileset.type === 'text_plain' || fileset.type === 'text_json' || fileset.type === 'text_format'),
   );
   const hasNtText = filesets.some(
     (fileset) =>
       (fileset.size === 'NT' ||
         fileset.size === 'NTP' ||
         fileset.size === 'C') &&
-      (fileset.type === 'text_plain' || fileset.type === 'text_format'),
+      (fileset.type === 'text_plain' || fileset.type === 'text_json' || fileset.type === 'text_format'),
   );
   let reference = '';
 
@@ -70,7 +70,7 @@ const getFirstChapterReference = (
     const textFormat = filesets.find(
       (fileset) =>
         (fileset.size === 'NT' || fileset.size === 'NTP' || fileset.size === 'C') &&
-        fileset.type === 'text_format',
+        (fileset.type === 'text_json' || fileset.type === 'text_format'),
     );
     const textPlain = filesets.find(
       (fileset) =>
@@ -105,7 +105,7 @@ const getFirstChapterReference = (
         (fileset.size === 'OT' ||
           fileset.size === 'OTP' ||
           fileset.size === 'C') &&
-        fileset.type === 'text_format',
+        (fileset.type === 'text_json' || fileset.type === 'text_format'),
     );
     const textPlain = filesets.find(
       (fileset) =>
@@ -180,7 +180,7 @@ const getFirstChapterReference = (
     const textFormat = filesets.find(
       (fileset) =>
         (fileset.size === 'NT' || fileset.size === 'NTP' || fileset.size === 'C') &&
-        fileset.type === 'text_format',
+        (fileset.type === 'text_json' || fileset.type === 'text_format'),
     );
     const textPlain = filesets.find(
       (fileset) =>
@@ -206,7 +206,7 @@ const getFirstChapterReference = (
         (fileset.size === 'OT' ||
           fileset.size === 'OTP' ||
           fileset.size === 'C') &&
-        fileset.type === 'text_format',
+        (fileset.type === 'text_json' || fileset.type === 'text_format'),
     );
     const textPlain = filesets.find(
       (fileset) =>

--- a/app/utils/requiresDom/addHighlight.js
+++ b/app/utils/requiresDom/addHighlight.js
@@ -23,7 +23,7 @@ const addHighlightUtil = ({
 	userId,
 	text,
 	highlights,
-	formattedSource,
+	hasFormattedSource,
 	userSettings,
 	activeTextId,
 	activeBookId,
@@ -160,7 +160,7 @@ const addHighlightUtil = ({
 			let anchorOffset = offset < focusOffset ? offset : focusOffset;
 			let anchorText = offset < focusOffset ? aText : focusText;
 			let node = aNode;
-			if (formattedSource.main) {
+			if (hasFormattedSource) {
 				if (aText !== focusText) {
 					// if nodes are different
 					// I have access to the parent node
@@ -270,10 +270,10 @@ const addHighlightUtil = ({
 			// Not so sure about this, seems like in theory it should give me the node closest to the beginning but idk
 			let highlightStart = 0;
 			let highlightedWords = 0;
-			const dist = calcDistance(lastVerse, firstVerse, !!formattedSource.main);
+			const dist = calcDistance(lastVerse, firstVerse, hasFormattedSource);
 			// Also need to check for class="v" to ensure that this was the first verse
 			if (
-				formattedSource.main &&
+				hasFormattedSource &&
 				!userSettings.getIn(['toggleOptions', 'readersMode', 'active']) &&
 				!userSettings.getIn(['toggleOptions', 'oneVersePerLine', 'active'])
 			) {

--- a/app/utils/tests/getInitialChapterData.test.js
+++ b/app/utils/tests/getInitialChapterData.test.js
@@ -2,6 +2,7 @@ import getInitialChapterData from '../getInitialChapterData';
 
 const params = {
   plainFilesetIds: ['ENGESV'],
+  formattedJsonFilesetIds: ['ENGESV'],
   formattedFilesetIds: ['ENGESV'],
   bookId: 'MAT',
   chapter: 1,
@@ -14,27 +15,32 @@ describe('get initial chapter data utility function', () => {
     expect(result).toHaveProperty('plainText');
     expect(result).toHaveProperty('plainTextJson');
     expect(result).toHaveProperty('formattedText');
+    expect(result).toHaveProperty('formattedJsonText');
   });
   it('should return correct default data with no filesets given', async () => {
     const result = await getInitialChapterData({
       ...params,
       plainFilesetIds: [],
       formattedFilesetIds: [],
+      formattedJsonFilesetIds: [],
     });
 
     expect(result).toHaveProperty('plainText', []);
     expect(result).toHaveProperty('plainTextJson', JSON.stringify({}));
     expect(result).toHaveProperty('formattedText', '');
+    expect(result).toHaveProperty('formattedJsonText', '');
   });
   it('should return correct default data on errors', async () => {
     const result = await getInitialChapterData({
       ...params,
       plainFilesetIds: ['asdf'],
       formattedFilesetIds: ['asdf'],
+      formattedJsonFilesetIds: ['asdf'],
     });
 
     expect(result).toHaveProperty('plainText', []);
     expect(result).toHaveProperty('plainTextJson', JSON.stringify({}));
     expect(result).toHaveProperty('formattedText', '');
+    expect(result).toHaveProperty('formattedJsonText', '');
   });
 });

--- a/pages/app.js
+++ b/pages/app.js
@@ -41,6 +41,7 @@ import hasFilesetVideo from '../app/utils/hasFilesetVideo';
 import removeStoriesFilesets from '../app/utils/removeStoriesFilesets';
 import {
   FILESET_TYPE_TEXT_PLAIN,
+  FILESET_TYPE_TEXT_JSON,
   FILESET_TYPE_TEXT_FORMAT,
   FILESET_TYPE_AUDIO_DRAMA,
   FILESET_TYPE_AUDIO,
@@ -130,8 +131,7 @@ function AppContainer(props) {
     const redLetter =
       !!props.formattedText &&
       !!(
-        props.formattedText.includes('class="wj"') ||
-        props.formattedText.includes("class='wj'")
+        props.formattedText.includes('usfm:wj')
       );
     props.dispatch({
       type: 'GET_INITIAL_ROUTE_STATE_SETTINGS',
@@ -139,8 +139,8 @@ function AppContainer(props) {
       crossReferences:
         !!props.formattedText &&
         !!(
-          props.formattedText.includes('class="ft"') ||
-          props.formattedText.includes('class="xt"')
+          props.formattedText.includes('usfm:ft') ||
+          props.formattedText.includes('usfm:xt')
         ),
     });
     props.dispatch(setChapterTextLoadingState({ state: false }));
@@ -416,6 +416,7 @@ AppContainer.getInitialProps = async (context) => {
     audio_drama: true,
     audio: true,
     text_plain: true,
+    text_json: true,
     text_format: true,
     video_stream: true,
   };
@@ -456,6 +457,12 @@ AppContainer.getInitialProps = async (context) => {
   }, []);
   const formattedFilesetIds = filesets.reduce((formattedFilesetResult, fileset) => {
     if (fileset.type === FILESET_TYPE_TEXT_FORMAT) {
+      formattedFilesetResult.push(fileset.id);
+    }
+    return formattedFilesetResult;
+  }, []);
+  const formattedJsonFilesetIds = filesets.reduce((formattedFilesetResult, fileset) => {
+    if (fileset.type === FILESET_TYPE_TEXT_JSON) {
       formattedFilesetResult.push(fileset.id);
     }
     return formattedFilesetResult;
@@ -561,6 +568,7 @@ AppContainer.getInitialProps = async (context) => {
       chapter,
       plainFilesetIds,
       formattedFilesetIds,
+      formattedJsonFilesetIds,
       audioType,
     }).catch((err) => {
       if (process.env.NODE_ENV === 'development') {
@@ -661,6 +669,7 @@ AppContainer.getInitialProps = async (context) => {
         chapterText,
         testaments,
         formattedSource: initData.formattedText,
+        formattedJsonSource: initData.formattedJsonText,
         activeFilesets: filesets,
         changingVersion: false,
         books: bookData || [],

--- a/public/app.scss
+++ b/public/app.scss
@@ -6,6 +6,7 @@
 @import './react-accessible-accordion.css';
 @import './variables';
 @import './global';
+@import './formatted_json';
 @import './formatted_text';
 @import './search';
 @import './chapterselection';

--- a/public/formatted_json.scss
+++ b/public/formatted_json.scss
@@ -1,0 +1,345 @@
+/**
+ * formattedTextStyles.scss
+ *
+ * SCSS styles for the FormattedText component, translating USFM marker concepts
+ * and functional states into CSS classes for web rendering.
+ * Inspired by React Native styles and provided class mappings.
+ */
+
+// --- Variables (Optional but recommended) ---
+$base-font-size: 16pt; // Example base font size (adjust as needed)
+$text-color: #333;
+$muted-text-color: #555;
+$highlight-bg-color: #accef7; // User text selection
+$playing-bg-color: rgba(255, 255, 0, 0.15); // Faint yellow for playing verse
+$footnote-marker-color: blue;
+$words-of-jesus-color: red;
+$base-line-height: 1.6;
+$base-margin: 0.75em; // Base vertical margin for blocks
+$indent-size: 1.5em; // Base indent size
+
+// --- Base Styling ---
+.bible-chapter-view {
+	font-size: $base-font-size; // Apply base font size here
+	line-height: $base-line-height;
+	color: $text-color;
+
+	// Justification Option
+	&.justify {
+		.verse-paragraph,
+		.verse-paragraph-noindent,
+		.verse-paragraph-indent {
+			text-align: justify;
+		}
+	}
+}
+
+.verse-content-item {
+	// Base styles for all rendered items (spans, divs, etc.)
+	// Most specific styling comes from the subtype classes below.
+}
+
+// --- Paragraphs & Text Blocks ---
+.verse-paragraph {
+	// usfm:p
+	margin-bottom: $base-margin * 0.75;
+	// Standard paragraphs might have a first-line indent depending on design
+}
+
+.verse-paragraph-noindent {
+	// usfm:m
+	margin-top: $base-margin;
+	margin-bottom: $base-margin;
+	text-indent: 0; // Explicitly no indent
+}
+
+.verse-paragraph-indent {
+	// usfm:pi (Assuming level 1)
+	margin-left: $indent-size;
+	margin-bottom: $base-margin * 0.75;
+	text-indent: 0; // Usually no *additional* indent needed
+}
+
+// Add .usfm-pi2, .usfm-pi3 etc. if needed, increasing margin-left
+
+.verse-list-item {
+	// usfm:li (Assuming level 1)
+	display: block;
+	margin-left: $indent-size;
+	margin-bottom: $base-margin * 0.5;
+}
+
+// Add .usfm-li2 etc. if needed
+
+.usfm-pc {
+	// Centered paragraph
+	text-align: center;
+	margin-top: $base-margin;
+	margin-bottom: $base-margin;
+}
+
+.usfm-cls {
+	// Closure paragraph
+	text-align: right; // Often right-aligned
+	margin-top: $base-margin;
+	margin-bottom: $base-margin;
+}
+
+// --- Poetry ---
+.verse-poetry {
+	// usfm:q, usfm:q1 (Base indent)
+	display: block;
+	margin-left: $indent-size * 1.5; // Example base poetry indent
+	margin-bottom: 0.1em; // Tight spacing
+}
+
+.verse-poetry-level2 {
+	// usfm:q2
+	margin-left: $indent-size * 2.5; // Increase indent
+}
+
+// Add .verse-poetry-level3, .verse-poetry-level4 if needed
+
+.usfm-qr {
+	// Poetry right-aligned
+	text-align: right;
+	margin-left: $indent-size * 1.5; // Maintain base indent
+	margin-bottom: 0.1em;
+}
+
+.usfm-qc {
+	// Poetry centered
+	text-align: center;
+	margin-left: 0; // Center within the container
+	margin-bottom: 0.1em;
+}
+
+.usfm-qa {
+	// Poetry attribution
+	display: block;
+	margin-left: $indent-size * 3; // Example indent, or align right
+	font-style: italic;
+	margin-top: $base-margin * 0.75;
+	margin-bottom: 0.1em;
+}
+
+.verse-blank-line {
+	// usfm:b
+	display: block;
+	height: $base-line-height * 0.8em; // Adjust spacing based on line height
+	content: ''; // Ensure it takes up space
+}
+
+.verse-inline-break {
+	// usfm:ib
+	// Often rendered as <br />, but if it's a span, style it:
+	display: block; // Force line break
+	height: 0;
+	margin: 0;
+	padding: 0;
+}
+
+// --- Titles & Headings ---
+.verse-main-title-1 {
+	// usfm:mt, usfm:mt1
+	display: block;
+	font-size: 1.8em; // Relative to base font size
+	font-weight: bold;
+	text-align: center;
+	margin-top: $base-margin * 1.5;
+	margin-bottom: $base-margin * 1.5;
+}
+
+.verse-main-title-2 {
+	// usfm:mt2
+	display: block;
+	font-size: 1.6em;
+	font-weight: bold; // Often still bold
+	text-align: center;
+	margin-top: $base-margin * 1.25;
+	margin-bottom: $base-margin * 1.25;
+}
+
+.verse-main-title-3 {
+	// usfm:mt2
+	display: block;
+	font-size: 1.4em;
+	font-weight: bold; // Often still bold
+	text-align: center;
+	margin-top: $base-margin * 1.25;
+	margin-bottom: $base-margin * 1.25;
+}
+
+.verse-section-heading {
+	// usfm:s, usfm:s1
+	display: block;
+	font-size: 1.3em;
+	font-weight: bold;
+	text-align: center; // Or left, depending on design
+	margin-top: $base-margin * 1.75;
+	margin-bottom: $base-margin;
+}
+
+// Add .usfm-s2 etc. if needed
+
+.verse-major-section-heading {
+	// usfm:ms
+	display: block;
+	font-size: 1.5em;
+	font-weight: bold;
+	text-align: center; // Or left
+	margin-top: $base-margin * 2.5;
+	margin-bottom: $base-margin * 1.25;
+}
+
+// Add .usfm-ms2 etc. if needed
+
+.usfm-mr {
+	// Major section reference range
+	display: block;
+	font-weight: bold;
+	text-align: center;
+	margin-top: $base-margin * 0.5;
+	margin-bottom: $base-margin * 1.5;
+}
+
+.usfm-r {
+	// Parallel passage reference heading
+	display: block;
+	text-align: right; // Often right-aligned
+	font-style: italic;
+	font-size: 0.9em;
+	margin-bottom: $base-margin;
+}
+
+// --- Character/Inline Styles (Applied as additional classes to spans) ---
+.usfm-bd {
+	font-weight: bold;
+}
+.usfm-it,
+.usfm-em,
+.usfm-bk,
+.usfm-sls,
+.usfm-qs {
+	font-style: italic;
+}
+.usfm-wj {
+	color: $words-of-jesus-color;
+}
+.verse-added-text {
+	// usfm:add
+	font-style: italic; // Example: Make added text italic
+	// Or add a subtle background/color
+}
+.usfm-sc {
+	font-variant: small-caps;
+}
+.usfm-fk {
+	// Footnote keyword
+	font-weight: bold;
+	font-style: italic;
+}
+.usfm-fq,
+.usfm-fqa {
+	// Footnote quotations
+	font-style: italic;
+}
+.usfm-ft {
+	// Base footnote text (applied within footnote display, not here)
+	// Define base style for footnote content if needed
+}
+
+// --- Markers & Labels ---
+.verse-number-label {
+	// verses_label
+	font-weight: bold;
+	color: $muted-text-color;
+	vertical-align: super;
+	font-size: 0.8em;
+	margin-right: 0.2em; // Space after number
+	cursor: pointer; // Indicate interactability
+	user-select: none; // Prevent selecting the number itself easily
+
+	// Styles for icons inside the label
+	.icon-wrapper {
+		display: inline-block; // Or inline-flex
+		vertical-align: middle; // Align icons with text nicely
+		margin-right: 0.25em;
+		cursor: pointer;
+		// Add default icon color, size if needed
+		svg {
+			// Style SVGs directly if used
+			width: 1em;
+			height: 1em;
+			fill: currentColor; // Inherit color
+		}
+		&:hover {
+			opacity: 0.7;
+		}
+	}
+	// Specific icon styles if needed
+	// .bookmark-icon { color: blue; }
+	// .note-icon { color: green; }
+}
+
+.chapter-number-label {
+	// chapter_label
+	display: block; // Rendered usually as a div/h1
+	font-size: 2.5em;
+	font-weight: bold;
+	text-align: center;
+	margin-top: $base-margin;
+	margin-bottom: $base-margin * 1.5;
+	color: $muted-text-color;
+}
+
+.verse-footnote-marker, // footnote
+.verse-crossref-marker {
+	// xref
+	color: $footnote-marker-color;
+	cursor: pointer;
+	vertical-align: super;
+	font-size: 0.8em;
+	margin: 0 0.1em; // Add slight horizontal spacing
+
+	&:hover {
+		text-decoration: underline;
+	}
+}
+
+// --- Functional Styles ---
+.verse-selectable {
+	// Base class for elements that can be part of verse interaction (clicking/selecting)
+	// Might not need specific styles itself, but useful as a hook.
+}
+
+.verse-playing {
+	// Style applied to spans/divs making up the currently playing verse
+	// Use a subtle background, avoiding interference with highlights
+	background-color: $playing-bg-color;
+	border-radius: 3px; // Match highlight radius if desired
+}
+
+.verse-selected {
+	// Style applied during user text selection
+	// Note: Browser default selection style might override this unless carefully managed
+	background-color: $highlight-bg-color;
+	color: #000; // Ensure text is readable over selection background
+}
+
+.verse-highlighted {
+	// Base class when a verse is highlighted (color applied inline)
+	border-radius: 3px;
+	padding: 0 0.1em; // Add slight padding for visual separation
+	// The actual background-color is applied via inline style by the component
+}
+
+// --- Other/Utility ---
+.verse-orphan-tokens, // orphanTokens
+.verse-remark {
+	// remark
+	font-size: 0.8em;
+	color: $muted-text-color;
+	margin-top: $base-margin * 2;
+	text-align: center; // Example styling
+}

--- a/public/textselector.scss
+++ b/public/textselector.scss
@@ -253,7 +253,6 @@
     width: 320px;
     max-width: 291px;
     padding: 15px;
-    // text-transform: capitalize;
   }
 }
 .version-name-list {
@@ -281,7 +280,6 @@
       width: 100%;
       text-align: center;
       font-size: 12px;
-      // text-transform: capitalize;
       @include css4 {
         background-color: var(--text-selection-accordion-title-background);
       }
@@ -299,7 +297,6 @@
       }
       padding-top: 15px;
       padding-bottom: 15px;
-      // text-transform: uppercase;
 
       & .accordion__button[aria-expanded='true'] {
         padding-bottom: 15px;
@@ -359,7 +356,6 @@
     display: flex;
     align-items: center;
     cursor: pointer;
-    // text-transform: capitalize;
 
     &:hover {
       color: inherit;
@@ -377,7 +373,6 @@
   padding: 15px;
 
   .country-error-message {
-    // text-transform: capitalize;
     width: 320px;
     max-width: 291px;
     padding: 15px;


### PR DESCRIPTION
# Description
Replaces text_format support with text_json for specially formatted book chapters. This commit also refactors the FormattedText component and removes dependencies on the text_format fileset type.

I added logic to switch between format and JSON content when formatted content is available in the fileset. JSON content has priority for rendering; otherwise, format content will be rendered.

# Task
[User Story 2696](https://dev.azure.com/keyholesoftware/FCBH%20-%20Bible%20Brain/_workitems/edit/2696): dbp-web: prefer text_json over text_format

# How to test it
You should run `npm run test` and it have to pass all tests, e.g.

``````shell
Test Suites: 75 passed, 75 total
Tests:       2 skipped, 415 passed, 417 total
Snapshots:   101 passed, 101 total
Time:        15.234 s, estimated 17 s
Ran all test suites.
``````

# Screenshot
- I have created a recording with some formatted bibles (JSON format) as you view in the following video:
[Peek 2025-04-29 14-50.webm](https://github.com/user-attachments/assets/c9559ea4-60f7-4bdf-a73b-4cc5a70bba19)

- I have created a recording about the `AA1WBT` bible (ext_format only)
[Peek 2025-04-29 17-43.webm](https://github.com/user-attachments/assets/afbcbcf6-762a-43ad-9370-2b2af7e7a137)

- Finally, you view see a screenshot for a plain text rendering (it is fake test to check that plain text rendering works).
![Screenshot from 2025-04-29 18-02-50](https://github.com/user-attachments/assets/47ebaba3-0425-439a-aecc-355482d88400)



