### PR TITLE
Task-2317 improve HTTPS‐redirect logic

### DIFF
--- a/nextServer.js
+++ b/nextServer.js
@@ -96,13 +96,13 @@ app
 				const userArray = userString.split(',');
 
 				res.redirect(
-					301,
+					302,
 					`${redirectPath}?user_id=${userArray[0]}&user_email=${
 						userArray[1]
 					}&user_name=${userArray[2]}`,
 				);
 			} else {
-				res.redirect(302, `${redirectPath}`);
+				res.redirect(302, redirectPath);
 			}
 		});
 
@@ -118,7 +118,7 @@ app
 			);
 			const userArray = userString.split(',');
 			res.redirect(
-				301,
+				302,
 				`/bible/ENGESV/MAT/1?user_id=${userArray[0]}&user_email=${
 					userArray[1]
 				}&user_name=${userArray[2]}`,
@@ -196,16 +196,16 @@ Disallow: /
 		const faviconOptions = {
 			root: `${__dirname}/public/`,
 		};
-		server.get('/favicon.ico', (req, res) =>
+		server.get('/favicon.ico', (_, res) =>
 			res.status(200).sendFile('favicon.ico', faviconOptions),
 		);
 
 		// Jesus Film Page
-		server.get('/jesus-film', (req, res) => {
+		server.get('/jesus-film', (_, res) => {
 			res.redirect(302, '/jesus-film/eng');
 		});
 
-		server.get('/jesus-film/:iso', (req, res) => {
+		server.get('/jesus-film/:iso', (req, res, nextP) => {
 			const actualPage = '/jesusFilm';
 			const iso = req.params.iso;
 
@@ -293,7 +293,7 @@ Disallow: /
 
 			if (bookId !== req.params.bookId) {
 				res.redirect(
-					301,
+					302,
 					`/bible/${req.params.bibleId}/${bookId}/${chapter}/${verse}`,
 				);
 			} else if (

--- a/pages/app.js
+++ b/pages/app.js
@@ -497,9 +497,7 @@ AppContainer.getInitialProps = async (context) => {
 			if (serverRes) {
 				// If there wasn't a book then we need to redirect to mark for video resources and matthew for other resources
 				serverRes.writeHead(301, {
-					Location: `${req.protocol}://${req.get(
-						'host',
-					)}/bible/${bibleId}/${bookChapterRoute}`,
+					Location: `/bible/${bibleId}/${bookChapterRoute}`,
 				});
 				serverRes.end();
 			} else {
@@ -515,13 +513,11 @@ AppContainer.getInitialProps = async (context) => {
 				// if the chapter was not found
 				// go to the book and the first chapter for that book
 				if (serverRes) {
-					serverRes.writeHead(301, {
-						Location: `${req.protocol}://${req.get(
-							'host',
-						)}/bible/${bibleId}/${foundBookId}/${foundChapterId}${
-							audioParam ? `?audio_type=${audioParam}` : ''
-						}`,
-					});
+					let location = `/bible/${bibleId}/${foundBookId}/${foundChapterId}`;
+					if (audioParam) {
+						location += `?audio_type=${audioParam}`;
+					}
+					serverRes.writeHead(301, { Location: location });
 					serverRes.end();
 				} else {
 					triggerRedirect.url = `/app?bibleId=${bibleId}&bookId=${foundBookId}&chapter=${foundChapterId}`;


### PR DESCRIPTION
# Description
Update all redirects to use relative URLs as Relative URLs preserve the current scheme and host automatically. This changes will work because the ALB already handles 80 -> 443 for us, so clients always hit your app over HTTPS in production.

# How to test it
If you run the following curl command you can view the different between newdata (it uses currently this change) and live

After change:
``````shell
curl -I https://newdata.bible.is/bible/ENGESV/
## output
HTTP/2 301 
date: Thu, 12 Jun 2025 14:52:02 GMT
server: nginx
x-powered-by: Express
location: /bible/ENGESV/GEN/1
``````

Before change:
``````shell
curl -I https://live.bible.is/bible/ENGESV/
## output
HTTP/2 301 
date: Thu, 12 Jun 2025 14:52:21 GMT
location: http://live.bible.is/bible/ENGESV/GEN/1
server: nginx
x-powered-by: Express
``````
