### PR TITLE
Update /languages endpoint requests in saga.js

### DIFF
--- a/app/containers/TextSelection/saga.js
+++ b/app/containers/TextSelection/saga.js
@@ -166,7 +166,7 @@ export function* getTexts({ languageCode, languageIso }) {
 }
 
 export function* getLanguages() {
-	const requestUrl = `/languages?has_filesets=true`;
+	const requestUrl = `/languages?has_filesets=true&limit=150`;
 
 	try {
 		const languages = [];
@@ -205,7 +205,7 @@ function sortLanguagesByVname(a, b) {
 }
 // Second call for the more robust language data
 export function* getLanguageAltNames() {
-	const requestUrl = `/languages?has_filesets=true&include_alt_names=true`;
+	const requestUrl = `/languages?has_filesets=true&include_alt_names=true&limit=150`;
 	try {
 		const languageData = [];
 


### PR DESCRIPTION
Added "&limit=150" to increase number of languages per Bible Brain API request from 50 to 150, reducing number of requests to our API from 52 to 17.

Current number of website requests to languages:
<img width="780" height="677" alt="image" src="https://github.com/user-attachments/assets/99aef10c-c443-4e78-b186-6fab14a4b987" />

New number of website requests to languages:
<img width="578" height="416" alt="image" src="https://github.com/user-attachments/assets/b4ec28d7-05fb-45c6-a4bd-079c6700c13d" />