### PR TITLE
Task-93807 Remove 10 UN Member States miscategorized in territoryCodes.json

### DIFF
--- a/app/utils/territoryCodes.json
+++ b/app/utils/territoryCodes.json
@@ -1,5 +1,4 @@
 {
-	"AG": true,
 	"AI": true,
 	"AN": true,
 	"AQ": true,
@@ -12,7 +11,6 @@
 	"CC": true,
 	"CK": true,
 	"CS": true,
-	"CV": true,
 	"CX": true,
 	"FK": true,
 	"FO": true,
@@ -28,7 +26,6 @@
 	"JE": true,
 	"KY": true,
 	"MF": true,
-	"MH": true,
 	"MO": true,
 	"MQ": true,
 	"MP": true,
@@ -39,20 +36,13 @@
 	"PF": true,
 	"PM": true,
 	"PN": true,
-	"SC": true,
 	"SH": true,
 	"SJ": true,
-	"SM": true,
-	"ST": true,
 	"SX": true,
 	"TC": true,
 	"TF": true,
 	"TK": true,
-	"TL": true,
-	"TT": true,
 	"UM": true,
-	"VC": true,
 	"VG": true,
-	"VI": true,
-	"WS": true
+	"VI": true
 }


### PR DESCRIPTION
# Issue Link
[Bug 93807](https://dev.azure.com/FCBH/Bible%20Brain/_workitems/edit/93807): Remove 10 UN Member States miscategorized in territoryCodes.json

# PR Summary: Unhide 10 UN Member States from the country selector

## Description

Users in several countries could not find their nation in the country drop-down on live.bible.is, even though languages for those regions exist in the catalog (confirmed by partners in Timor-Leste).

The country list is filtered by `app/utils/territoryCodes.json` — any country whose ISO `iso_a2` code is a key in this file is excluded.

## Change

Removed 10 country codes from `app/utils/territoryCodes.json`:

| Code | UN Member State |
|------|-----------------|
| AG | Antigua and Barbuda |
| CV | Cabo Verde |
| MH | Marshall Islands |
| SC | Seychelles |
| SM | San Marino |
| ST | Sao Tome and Principe |
| TL | Timor-Leste |
| TT | Trinidad and Tobago |
| VC | Saint Vincent and the Grenadines |
| WS | Samoa |

The filter lives in `getCountries()` at `app/containers/TextSelection/saga.js:49`. No code changes were needed — removing the keys lets these countries flow through to the dropdown.

## Verification

- `npm run lint:js` — 0 errors.
- `npm run test` — 79 suites pass (491 passed, 2 skipped, 115 snapshots). The
  `CountryList` snapshot tests use fixed test data and are unaffected.
- Manual: the 10 nations now appear in the country selector and can be selected to show their available languages.

# Screenshot
You can see a screenshot after applied the current change.
<img width="1363" height="957" alt="Screenshot_2026-06-17_11-12-38" src="https://github.com/user-attachments/assets/41bd55bf-290f-45b2-b867-204fe5081518" />
