### PR TITLE
Remove sensitive exported-variables from buildspec.yml [DEVELOP]

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -1,9 +1,7 @@
 version: 0.2
 env:
   exported-variables:
-    - DBP_API_KEY
     - BASE_API_ROUTE
-    - BUGSNAG_API_KEY
 phases:
   install:
     runtime-versions:


### PR DESCRIPTION
Remove sensitive exported-variables from buildspec.yml

## Background
AWS CodeBuild fails with the following error when attempting to export sensitive environment variables from AWS Systems Manager Parameter Store or Secrets Manager:

YAML_FILE_ERROR: Cannot export sensitive environment variables

## Changes
This PR removes the following sensitive variables from the exported-variables section in buildspec.yml:
- DBP_API_KEY
- BUGSNAG_API_KEY

Only BASE_API_ROUTE is retained as it is not a sensitive variable.

Before:
```
env:
  exported-variables:
    - DBP_API_KEY
    - BASE_API_ROUTE
    - BUGSNAG_API_KEY
```

After:
```
env:
  exported-variables:
    - BASE_API_ROUTE
```

## Technical Context
- These variables are now sourced from AWS Systems Manager Parameter Store
- AWS CodeBuild does not allow exporting environment variables from Parameter Store or Secrets Manager due to security restrictions
- The variables are still available during the build process, but cannot be exported to downstream phases
- A temporary buildspec override was applied to the CodeBuild project to allow the deployment to proceed

## Testing
- Build completes successfully without the YAML_FILE_ERROR
- Application still has access to sensitive variables during runtime
- Variables are properly sourced from Parameter Store

## Deployment
This PR is for the DEV environment (develop branch)